### PR TITLE
Add template system and auto-clone workspace management

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,14 +81,46 @@ ci:
   poll_interval: 30
 ```
 
+## Target repo integration
+
+Target repos can override config and templates by adding a `.aiorchestra/` directory:
+
+```
+your-project/
+├── .aiorchestra/
+│   ├── config.yaml        # Override test commands, retry limits, etc.
+│   └── templates/         # Override any prompt template
+│       └── implement.md   # Custom implementation prompt
+├── CLAUDE.md              # Agent instructions (read by Claude Code)
+└── ...
+```
+
+**Resolution order** (first found wins for templates, layered merge for config):
+
+| Layer | Templates | Config |
+|-------|-----------|--------|
+| 1. Target repo | `.aiorchestra/templates/*.md` | `.aiorchestra/config.yaml` |
+| 2. AIOrchestra defaults | `aiorchestra/templates/*.md` | Built-in `DEFAULTS` |
+
+**Built-in templates:** `implement`, `fix_validation`, `fix_ci`, `review`, `fix_review` — each uses `{variable}` placeholders filled by the pipeline.
+
+**Agent instructions** (CLAUDE.md, AGENTS.md, etc.) belong in the target repo, not AIOrchestra. They describe that codebase's conventions and are read directly by the AI agent.
+
 ## Project structure
 
 ```
 aiorchestra/
 ├── __init__.py
 ├── cli.py            # CLI entry point
-├── config.py         # Config loader
+├── config.py         # Config loader (3-layer merge)
 ├── pipeline.py       # Stage runner / state machine
+├── templates/
+│   ├── __init__.py   # Template loader with override resolution
+│   ├── implement.md  # Default implementation prompt
+│   ├── fix_validation.md
+│   ├── fix_ci.md
+│   ├── review.md
+│   └── fix_review.md
 ├── stages/
 │   ├── __init__.py
 │   ├── discover.py   # Find labeled issues
@@ -100,7 +132,7 @@ aiorchestra/
 │   └── review.py     # AI code review
 └── ai/
     ├── __init__.py
-    └── claude.py     # Claude Code CLI + API wrapper
+    └── claude.py     # Claude Code CLI wrapper
 ```
 
 ## Design principles

--- a/aiorchestra/config.py
+++ b/aiorchestra/config.py
@@ -1,4 +1,10 @@
-"""Configuration loader."""
+"""Configuration loader.
+
+Resolution order (each layer merges on top of the previous):
+  1. Built-in defaults
+  2. Target repo .aiorchestra/config.yaml (if repo_root provided)
+  3. Explicit --config path (if provided)
+"""
 
 from pathlib import Path
 
@@ -39,18 +45,29 @@ def _deep_merge(base: dict, override: dict) -> dict:
     return result
 
 
-def load_config(path: str | None = None) -> dict:
-    """Load config from YAML file, falling back to defaults."""
+def _load_yaml(path: Path) -> dict:
+    with open(path) as f:
+        return yaml.safe_load(f) or {}
+
+
+def load_config(path: str | None = None, repo_root: str | None = None) -> dict:
+    """Load config by merging defaults ← repo config ← explicit config."""
+    config = DEFAULTS.copy()
+
+    # Layer 2: target repo .aiorchestra/config.yaml
+    if repo_root:
+        repo_config = Path(repo_root) / ".aiorchestra" / "config.yaml"
+        if repo_config.exists():
+            config = _deep_merge(config, _load_yaml(repo_config))
+
+    # Layer 3: explicit --config path
     if path is None:
-        # Try common locations
         for candidate in ["aiorchestra.yaml", "aiorchestra.yml"]:
             if Path(candidate).exists():
                 path = candidate
                 break
 
     if path and Path(path).exists():
-        with open(path) as f:
-            user_config = yaml.safe_load(f) or {}
-        return _deep_merge(DEFAULTS, user_config)
+        config = _deep_merge(config, _load_yaml(Path(path)))
 
-    return DEFAULTS.copy()
+    return config

--- a/aiorchestra/pipeline.py
+++ b/aiorchestra/pipeline.py
@@ -9,6 +9,7 @@ from aiorchestra.stages.validate import validate
 from aiorchestra.stages.publish import publish
 from aiorchestra.stages.ci import wait_for_ci
 from aiorchestra.stages.review import review
+from aiorchestra.templates import render_template
 
 log = logging.getLogger(__name__)
 
@@ -21,12 +22,14 @@ class Pipeline:
         config: dict,
         issue_number: int | None = None,
         dry_run: bool = False,
+        repo_root: str | None = None,
     ):
         self.repo = repo
         self.label = label
         self.issue_number = issue_number
         self.config = config
         self.dry_run = dry_run
+        self.repo_root = repo_root
         self.max_retries = config.get("ai", {}).get("max_retries", 3)
 
     def run(self) -> int:
@@ -61,7 +64,8 @@ class Pipeline:
             log.info("Implementation attempt %d/%d", attempt, self.max_retries)
 
             errors = None if attempt == 1 else validation_errors
-            if not implement(issue, self.config, previous_errors=errors):
+            if not implement(issue, self.config, previous_errors=errors,
+                             repo_root=self.repo_root):
                 return False
 
             ok, validation_errors = validate(self.config)
@@ -83,7 +87,17 @@ class Pipeline:
                 if ok:
                     break
                 log.info("CI failed, attempt %d/%d", attempt, self.max_retries)
-                if not implement(issue, self.config, previous_errors=ci_output):
+
+                ci_prompt_errors = render_template(
+                    "fix_ci",
+                    repo_root=self.repo_root,
+                    number=issue["number"],
+                    title=issue["title"],
+                    body=issue.get("body", ""),
+                    errors=ci_output,
+                )
+                if not implement(issue, self.config, previous_errors=ci_prompt_errors,
+                                 repo_root=self.repo_root):
                     return False
             else:
                 log.error("CI failed after %d attempts", self.max_retries)
@@ -92,11 +106,22 @@ class Pipeline:
         # Stage 5: Review (AI) + fix loop
         if self.config.get("review", {}).get("enabled", True):
             for attempt in range(1, self.max_retries + 1):
-                ok, feedback = review(self.repo, branch, self.config)
+                ok, feedback = review(self.repo, branch, self.config, issue=issue,
+                                      repo_root=self.repo_root)
                 if ok:
                     break
                 log.info("Review flagged issues, attempt %d/%d", attempt, self.max_retries)
-                if not implement(issue, self.config, previous_errors=feedback):
+
+                review_errors = render_template(
+                    "fix_review",
+                    repo_root=self.repo_root,
+                    number=issue["number"],
+                    title=issue["title"],
+                    body=issue.get("body", ""),
+                    errors=feedback,
+                )
+                if not implement(issue, self.config, previous_errors=review_errors,
+                                 repo_root=self.repo_root):
                     return False
             else:
                 log.error("Review failed after %d attempts", self.max_retries)

--- a/aiorchestra/stages/implement.py
+++ b/aiorchestra/stages/implement.py
@@ -3,26 +3,40 @@
 import logging
 
 from aiorchestra.ai.claude import invoke_claude
+from aiorchestra.templates import render_template
 
 log = logging.getLogger(__name__)
 
 
-def _build_prompt(issue: dict, previous_errors: str | None = None) -> str:
+def _build_prompt(
+    issue: dict, repo_root: str | None = None, previous_errors: str | None = None
+) -> str:
     """Build a focused prompt from the issue and optional error context."""
-    parts = [
-        f"Implement the following GitHub issue.\n",
-        f"Issue #{issue['number']}: {issue['title']}\n",
-        f"{issue.get('body', '')}\n",
-        "Do NOT run tests — just implement the changes.",
-    ]
     if previous_errors:
-        parts.append(f"\nPrevious attempt failed with these errors:\n{previous_errors}")
-        parts.append("\nFix these errors in your implementation.")
-    return "\n".join(parts)
+        return render_template(
+            "fix_validation",
+            repo_root=repo_root,
+            number=issue["number"],
+            title=issue["title"],
+            body=issue.get("body", ""),
+            errors=previous_errors,
+        )
+    return render_template(
+        "implement",
+        repo_root=repo_root,
+        number=issue["number"],
+        title=issue["title"],
+        body=issue.get("body", ""),
+    )
 
 
-def implement(issue: dict, config: dict, previous_errors: str | None = None) -> bool:
+def implement(
+    issue: dict,
+    config: dict,
+    previous_errors: str | None = None,
+    repo_root: str | None = None,
+) -> bool:
     """Invoke the AI to implement changes. Returns True on success."""
-    prompt = _build_prompt(issue, previous_errors)
+    prompt = _build_prompt(issue, repo_root, previous_errors)
     ai_config = config.get("ai", {})
     return invoke_claude(prompt, ai_config)

--- a/aiorchestra/stages/review.py
+++ b/aiorchestra/stages/review.py
@@ -4,13 +4,16 @@ import logging
 import subprocess
 
 from aiorchestra.ai.claude import invoke_claude
+from aiorchestra.templates import render_template
 
 log = logging.getLogger(__name__)
 
 
-def review(repo: str, branch: str, config: dict) -> tuple[bool, str | None]:
+def review(
+    repo: str, branch: str, config: dict, issue: dict | None = None,
+    repo_root: str | None = None,
+) -> tuple[bool, str | None]:
     """Run AI code review on the current diff. Returns (passed, feedback)."""
-    # Get the diff (deterministic)
     result = subprocess.run(
         ["git", "diff", "origin/main...HEAD"],
         capture_output=True, text=True,
@@ -21,14 +24,11 @@ def review(repo: str, branch: str, config: dict) -> tuple[bool, str | None]:
         log.warning("No diff to review.")
         return True, None
 
-    prompt = (
-        "Review the following code diff. Focus on:\n"
-        "- Bugs or logic errors\n"
-        "- Security issues\n"
-        "- Missing edge cases\n\n"
-        "If the code looks good, respond with exactly: LGTM\n"
-        "If there are issues, describe them clearly.\n\n"
-        f"```diff\n{diff}\n```"
+    number = issue["number"] if issue else 0
+    title = issue["title"] if issue else "unknown"
+
+    prompt = render_template(
+        "review", repo_root=repo_root, number=number, title=title, diff=diff,
     )
 
     review_config = config.get("review", {})

--- a/aiorchestra/templates/__init__.py
+++ b/aiorchestra/templates/__init__.py
@@ -1,0 +1,46 @@
+"""Template loader with two-layer resolution.
+
+Resolution order (first found wins):
+  1. {target_repo}/.aiorchestra/templates/{name}.md
+  2. {aiorchestra}/templates/{name}.md  (built-in defaults)
+"""
+
+from pathlib import Path
+
+_BUILTIN_DIR = Path(__file__).parent
+
+
+def load_template(name: str, repo_root: str | None = None) -> str:
+    """Load a template by name, checking repo overrides first.
+
+    Args:
+        name: Template name without extension (e.g. "implement").
+        repo_root: Path to the target repo root. If provided, checks
+                   {repo_root}/.aiorchestra/templates/ first.
+
+    Returns:
+        The template string with {placeholders} ready for .format().
+
+    Raises:
+        FileNotFoundError: If the template doesn't exist anywhere.
+    """
+    filename = f"{name}.md"
+
+    # Check repo override first
+    if repo_root:
+        override = Path(repo_root) / ".aiorchestra" / "templates" / filename
+        if override.exists():
+            return override.read_text()
+
+    # Fall back to built-in
+    builtin = _BUILTIN_DIR / filename
+    if builtin.exists():
+        return builtin.read_text()
+
+    raise FileNotFoundError(f"Template '{name}' not found")
+
+
+def render_template(name: str, repo_root: str | None = None, **kwargs) -> str:
+    """Load and render a template with the given variables."""
+    template = load_template(name, repo_root)
+    return template.format(**kwargs)

--- a/aiorchestra/templates/fix_ci.md
+++ b/aiorchestra/templates/fix_ci.md
@@ -1,0 +1,11 @@
+CI failed for issue #{number}.
+
+Issue #{number}: {title}
+
+{body}
+
+CI output:
+
+{errors}
+
+Fix the issues causing CI to fail. Do NOT run tests — just fix the code.

--- a/aiorchestra/templates/fix_review.md
+++ b/aiorchestra/templates/fix_review.md
@@ -1,0 +1,11 @@
+Code review flagged issues with your implementation of issue #{number}.
+
+Issue #{number}: {title}
+
+{body}
+
+Review feedback:
+
+{errors}
+
+Address the review feedback. Do NOT run tests — just fix the code.

--- a/aiorchestra/templates/fix_validation.md
+++ b/aiorchestra/templates/fix_validation.md
@@ -1,0 +1,11 @@
+Your previous implementation for issue #{number} failed validation.
+
+Issue #{number}: {title}
+
+{body}
+
+The following errors occurred:
+
+{errors}
+
+Fix these errors. Do NOT run tests — just fix the code.

--- a/aiorchestra/templates/implement.md
+++ b/aiorchestra/templates/implement.md
@@ -1,0 +1,7 @@
+Implement the following GitHub issue.
+
+Issue #{number}: {title}
+
+{body}
+
+Do NOT run tests — just implement the changes.

--- a/aiorchestra/templates/review.md
+++ b/aiorchestra/templates/review.md
@@ -1,0 +1,13 @@
+Review the following code diff for issue #{number}: {title}
+
+Focus on:
+- Bugs or logic errors
+- Security issues
+- Missing edge cases
+
+If the code looks good, respond with exactly: LGTM
+If there are issues, describe them clearly.
+
+```diff
+{diff}
+```

--- a/tests/test_templates.py
+++ b/tests/test_templates.py
@@ -1,0 +1,36 @@
+"""Tests for template loading and resolution."""
+
+import tempfile
+from pathlib import Path
+
+from aiorchestra.templates import load_template, render_template
+
+
+def test_builtin_templates_exist():
+    for name in ["implement", "fix_validation", "fix_ci", "review", "fix_review"]:
+        template = load_template(name)
+        assert "{number}" in template
+
+
+def test_render_template():
+    result = render_template("implement", number=42, title="Add feature", body="Details here")
+    assert "42" in result
+    assert "Add feature" in result
+    assert "Details here" in result
+
+
+def test_repo_override():
+    with tempfile.TemporaryDirectory() as tmpdir:
+        override_dir = Path(tmpdir) / ".aiorchestra" / "templates"
+        override_dir.mkdir(parents=True)
+        (override_dir / "implement.md").write_text("Custom: {number}")
+
+        result = render_template("implement", repo_root=tmpdir, number=99)
+        assert result == "Custom: 99"
+
+
+def test_repo_override_falls_back():
+    with tempfile.TemporaryDirectory() as tmpdir:
+        # No .aiorchestra/templates/ dir — should fall back to built-in
+        result = load_template("implement", repo_root=tmpdir)
+        assert "{number}" in result


### PR DESCRIPTION
## Summary

- Add 5 built-in prompt templates (`implement`, `fix_validation`, `fix_ci`, `review`, `fix_review`) with `{variable}` placeholders
- Add 2-layer template resolution: target repo `.aiorchestra/templates/` overrides built-in defaults
- Extend config loading to 3 layers: defaults ← repo `.aiorchestra/config.yaml` ← explicit `--config`
- Auto-clone repos via `gh repo clone` into `~/.aiorchestra/workspaces/` (or custom `--workspace`)
- Prepare stage handles full setup from scratch: clone, fetch, branch, install deps
- Add `--workspace` and `--verbose` CLI flags, wire up logging

### Usage from zero (no git clone needed)

```bash
pip install -e /path/to/AIOrchestra
aiorchestra run --repo owner/repo --label claude
```

### Target repo overrides (optional)

```
your-project/
├── .aiorchestra/
│   ├── config.yaml        # Override test commands, retry limits, etc.
│   └── templates/
│       └── implement.md   # Custom implementation prompt
├── CLAUDE.md              # Agent instructions (read by Claude Code directly)
```

## Test plan

- [x] All 6 tests pass (`test_config` + `test_templates`)
- [ ] Verify template override with a real `.aiorchestra/templates/` directory in a target repo
- [ ] End-to-end: `aiorchestra run --repo ironharvy/story_writer --label claude --dry-run -v`

https://claude.ai/code/session_01PsyvVpEZBAoEtJB8eawiDH