### PR TITLE
Add template system and auto-clone workspace management

### DIFF
--- a/aiorchestra/cli.py
+++ b/aiorchestra/cli.py
@@ -1,6 +1,7 @@
 """CLI entry point for AIOrchestra."""
 
 import argparse
+import logging
 import sys
 
 from aiorchestra.config import load_config
@@ -19,7 +20,10 @@ def build_parser() -> argparse.ArgumentParser:
     run.add_argument("--label", default=None, help="Issue label to filter by")
     run.add_argument("--issue", type=int, default=None, help="Specific issue number")
     run.add_argument("--config", default=None, help="Path to config YAML")
+    run.add_argument("--workspace", default=None,
+                     help="Directory for cloned repos (default: ~/.aiorchestra/workspaces)")
     run.add_argument("--dry-run", action="store_true", help="Show plan without executing")
+    run.add_argument("--verbose", "-v", action="store_true", help="Verbose logging")
 
     return parser
 
@@ -32,6 +36,12 @@ def main(argv: list[str] | None = None) -> int:
         parser.print_help()
         return 1
 
+    logging.basicConfig(
+        level=logging.DEBUG if getattr(args, "verbose", False) else logging.INFO,
+        format="%(asctime)s [%(levelname)s] %(name)s: %(message)s",
+        datefmt="%H:%M:%S",
+    )
+
     if args.command == "run":
         config = load_config(args.config)
         pipeline = Pipeline(
@@ -40,6 +50,7 @@ def main(argv: list[str] | None = None) -> int:
             issue_number=args.issue,
             config=config,
             dry_run=args.dry_run,
+            workspace=args.workspace,
         )
         return pipeline.run()
 

--- a/aiorchestra/pipeline.py
+++ b/aiorchestra/pipeline.py
@@ -1,6 +1,7 @@
 """Pipeline — the state machine that drives each issue through stages."""
 
 import logging
+import os
 
 from aiorchestra.stages.discover import discover_issues
 from aiorchestra.stages.prepare import prepare_environment
@@ -22,14 +23,14 @@ class Pipeline:
         config: dict,
         issue_number: int | None = None,
         dry_run: bool = False,
-        repo_root: str | None = None,
+        workspace: str | None = None,
     ):
         self.repo = repo
         self.label = label
         self.issue_number = issue_number
         self.config = config
         self.dry_run = dry_run
-        self.repo_root = repo_root
+        self.workspace = workspace
         self.max_retries = config.get("ai", {}).get("max_retries", 3)
 
     def run(self) -> int:
@@ -56,16 +57,22 @@ class Pipeline:
         branch = f"{self.config.get('branch_prefix', 'auto/')}{issue['number']}"
 
         # Stage 1: Prepare environment (deterministic)
-        if not prepare_environment(self.repo, branch):
+        repo_root = prepare_environment(self.repo, branch, self.workspace)
+        if not repo_root:
             return False
 
+        # All subsequent commands run inside the target repo
+        os.chdir(repo_root)
+        log.info("Working in %s", repo_root)
+
         # Stage 2: Implement (AI) + Validate (deterministic), with retries
+        validation_errors = None
         for attempt in range(1, self.max_retries + 1):
             log.info("Implementation attempt %d/%d", attempt, self.max_retries)
 
             errors = None if attempt == 1 else validation_errors
             if not implement(issue, self.config, previous_errors=errors,
-                             repo_root=self.repo_root):
+                             repo_root=repo_root):
                 return False
 
             ok, validation_errors = validate(self.config)
@@ -90,14 +97,14 @@ class Pipeline:
 
                 ci_prompt_errors = render_template(
                     "fix_ci",
-                    repo_root=self.repo_root,
+                    repo_root=repo_root,
                     number=issue["number"],
                     title=issue["title"],
                     body=issue.get("body", ""),
                     errors=ci_output,
                 )
                 if not implement(issue, self.config, previous_errors=ci_prompt_errors,
-                                 repo_root=self.repo_root):
+                                 repo_root=repo_root):
                     return False
             else:
                 log.error("CI failed after %d attempts", self.max_retries)
@@ -107,21 +114,21 @@ class Pipeline:
         if self.config.get("review", {}).get("enabled", True):
             for attempt in range(1, self.max_retries + 1):
                 ok, feedback = review(self.repo, branch, self.config, issue=issue,
-                                      repo_root=self.repo_root)
+                                      repo_root=repo_root)
                 if ok:
                     break
                 log.info("Review flagged issues, attempt %d/%d", attempt, self.max_retries)
 
                 review_errors = render_template(
                     "fix_review",
-                    repo_root=self.repo_root,
+                    repo_root=repo_root,
                     number=issue["number"],
                     title=issue["title"],
                     body=issue.get("body", ""),
                     errors=feedback,
                 )
                 if not implement(issue, self.config, previous_errors=review_errors,
-                                 repo_root=self.repo_root):
+                                 repo_root=repo_root):
                     return False
             else:
                 log.error("Review failed after %d attempts", self.max_retries)

--- a/aiorchestra/stages/prepare.py
+++ b/aiorchestra/stages/prepare.py
@@ -1,30 +1,79 @@
 """Prepare the working environment. Pure shell — no AI tokens spent."""
 
 import logging
+import os
 import subprocess
+from pathlib import Path
 
 log = logging.getLogger(__name__)
 
+DEFAULT_WORKSPACE = Path.home() / ".aiorchestra" / "workspaces"
 
-def _run(cmd: list[str], check: bool = True) -> subprocess.CompletedProcess:
+
+def _run(cmd: list[str], check: bool = True, cwd: str | None = None) -> subprocess.CompletedProcess:
     log.info("Running: %s", " ".join(cmd))
-    return subprocess.run(cmd, capture_output=True, text=True, check=check)
+    return subprocess.run(cmd, capture_output=True, text=True, check=check, cwd=cwd)
 
 
-def prepare_environment(repo: str, branch: str) -> bool:
-    """Pull latest, create branch, set up venv if needed.
+def prepare_environment(repo: str, branch: str, workspace: str | None = None) -> str | None:
+    """Clone (if needed), pull latest, create branch.
 
-    Returns True on success.
+    Args:
+        repo: GitHub repo in "owner/repo" format.
+        branch: Branch name to create.
+        workspace: Root directory for cloned repos. Defaults to ~/.aiorchestra/workspaces.
+
+    Returns:
+        Path to the repo working directory, or None on failure.
     """
+    workspace_root = Path(workspace) if workspace else DEFAULT_WORKSPACE
+    repo_name = repo.split("/")[-1]
+    repo_dir = workspace_root / repo_name
+
     try:
-        _run(["git", "fetch", "origin"])
-        _run(["git", "checkout", "-b", branch, "origin/main"], check=False)
+        # Clone if the repo dir doesn't exist
+        if not (repo_dir / ".git").exists():
+            log.info("Cloning %s into %s", repo, repo_dir)
+            repo_dir.mkdir(parents=True, exist_ok=True)
+            _run(
+                ["gh", "repo", "clone", repo, str(repo_dir)],
+            )
+        else:
+            log.info("Repo already cloned at %s", repo_dir)
 
-        # Activate venv if it exists, install deps
-        # (venv activation doesn't persist across subprocess calls,
-        #  so we'll use the venv python directly in later stages)
+        # Fetch latest and create branch
+        _run(["git", "fetch", "origin"], cwd=str(repo_dir))
 
-        return True
+        # Try to create branch; if it exists, just check it out
+        result = _run(
+            ["git", "checkout", "-b", branch, "origin/main"],
+            check=False, cwd=str(repo_dir),
+        )
+        if result.returncode != 0:
+            log.info("Branch may exist, trying checkout: %s", branch)
+            _run(["git", "checkout", branch], cwd=str(repo_dir))
+            _run(["git", "merge", "origin/main", "--no-edit"], check=False, cwd=str(repo_dir))
+
+        # Install deps if common files exist
+        _install_deps(repo_dir)
+
+        return str(repo_dir)
+
     except subprocess.CalledProcessError as exc:
         log.error("Prepare failed: %s", exc.stderr)
-        return False
+        return None
+
+
+def _install_deps(repo_dir: Path) -> None:
+    """Best-effort dependency installation."""
+    cwd = str(repo_dir)
+
+    if (repo_dir / "requirements.txt").exists():
+        log.info("Installing from requirements.txt")
+        _run(["pip", "install", "-r", "requirements.txt"], check=False, cwd=cwd)
+    elif (repo_dir / "pyproject.toml").exists():
+        log.info("Installing from pyproject.toml")
+        _run(["pip", "install", "-e", "."], check=False, cwd=cwd)
+    elif (repo_dir / "setup.py").exists():
+        log.info("Installing from setup.py")
+        _run(["pip", "install", "-e", "."], check=False, cwd=cwd)


### PR DESCRIPTION
## Summary

- Add 5 built-in prompt templates (`implement`, `fix_validation`, `fix_ci`, `review`, `fix_review`) with `{variable}` placeholders
- Add 2-layer template resolution: target repo `.aiorchestra/templates/` overrides built-in defaults
- Extend config loading to 3 layers: defaults ← repo `.aiorchestra/config.yaml` ← explicit `--config`
- Auto-clone repos via `gh repo clone` into `~/.aiorchestra/workspaces/` (or custom `--workspace`)
- Prepare stage handles full setup from scratch: clone, fetch, branch, install deps
- Add `--workspace` and `--verbose` CLI flags, wire up logging

### Usage from zero (no git clone needed)

```bash
pip install -e /path/to/AIOrchestra
aiorchestra run --repo owner/repo --label claude
```

### Target repo overrides (optional)

```
your-project/
├── .aiorchestra/
│   ├── config.yaml        # Override test commands, retry limits, etc.
│   └── templates/
│       └── implement.md   # Custom implementation prompt
├── CLAUDE.md              # Agent instructions (read by Claude Code directly)
```

## Test plan

- [x] All 6 tests pass (`test_config` + `test_templates`)
- [ ] Verify template override with a real `.aiorchestra/templates/` directory in a target repo
- [ ] End-to-end: `aiorchestra run --repo ironharvy/story_writer --label claude --dry-run -v`

https://claude.ai/code/session_01PsyvVpEZBAoEtJB8eawiDH