### PR TITLE
Format code with Ruff and add linting to CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,6 +6,20 @@ on:
   pull_request:
 
 jobs:
+  lint:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+      - name: Install dependencies
+        run: pip install -e ".[dev]"
+      - name: Ruff check
+        run: ruff check .
+      - name: Ruff format
+        run: ruff format --check .
+
   test:
     runs-on: ubuntu-latest
     steps:

--- a/aiorchestra/_logging.py
+++ b/aiorchestra/_logging.py
@@ -6,10 +6,10 @@ import sys
 _RESET = "\033[0m"
 
 _LEVEL_COLORS = {
-    logging.DEBUG: "\033[2m",        # dim
-    logging.INFO: "\033[36m",        # cyan
-    logging.WARNING: "\033[33m",     # yellow
-    logging.ERROR: "\033[31m",       # red
+    logging.DEBUG: "\033[2m",  # dim
+    logging.INFO: "\033[36m",  # cyan
+    logging.WARNING: "\033[33m",  # yellow
+    logging.ERROR: "\033[31m",  # red
     logging.CRITICAL: "\033[1;31m",  # bold red
 }
 
@@ -29,9 +29,7 @@ class ColorFormatter(logging.Formatter):
 
         record.levelname_colored = f"{level_color}{record.levelname}{_RESET}"
         record.name_colored = f"{_NAME_COLOR}{record.name}{_RESET}"
-        record.asctime_colored = (
-            f"{_TIME_COLOR}{self.formatTime(record, self.datefmt)}{_RESET}"
-        )
+        record.asctime_colored = f"{_TIME_COLOR}{self.formatTime(record, self.datefmt)}{_RESET}"
         record.msg_colored = f"{level_color}{record.getMessage()}{_RESET}"
 
         return (

--- a/aiorchestra/ai/claude.py
+++ b/aiorchestra/ai/claude.py
@@ -11,7 +11,8 @@ log = logging.getLogger(__name__)
 
 # Marker the agent emits when the task description is ambiguous.
 _CLARIFICATION_RE = re.compile(
-    r"^NEEDS_CLARIFICATION:\s*(.+)", re.MULTILINE | re.DOTALL,
+    r"^NEEDS_CLARIFICATION:\s*(.+)",
+    re.MULTILINE | re.DOTALL,
 )
 
 
@@ -78,8 +79,7 @@ def _invoke_cli(
 
     if not skip_perms and not allowed_tools:
         log.error(
-            "AI agent has no file-editing permissions — "
-            "refusing to invoke without tool access"
+            "AI agent has no file-editing permissions — refusing to invoke without tool access"
         )
         return InvokeResult(success=False)
 

--- a/aiorchestra/cli.py
+++ b/aiorchestra/cli.py
@@ -21,8 +21,11 @@ def build_parser() -> argparse.ArgumentParser:
     run.add_argument("--label", default=None, help="Issue label to filter by")
     run.add_argument("--issue", type=int, default=None, help="Specific issue number")
     run.add_argument("--config", default=None, help="Path to config YAML")
-    run.add_argument("--workspace", default=None,
-                     help="Directory for cloned repos (default: ~/.aiorchestra/workspaces)")
+    run.add_argument(
+        "--workspace",
+        default=None,
+        help="Directory for cloned repos (default: ~/.aiorchestra/workspaces)",
+    )
     run.add_argument("--dry-run", action="store_true", help="Show plan without executing")
     run.add_argument("--verbose", "-v", action="store_true", help="Verbose logging")
 
@@ -31,16 +34,18 @@ def build_parser() -> argparse.ArgumentParser:
         help="Scan all owned repos for 'aiorchestra'-labeled issues",
     )
     dispatch.add_argument(
-        "--owner", default="@me",
+        "--owner",
+        default="@me",
         help="GitHub owner to scan (default: @me, i.e. the authenticated user)",
     )
     dispatch.add_argument("--config", default=None, help="Path to config YAML")
-    dispatch.add_argument("--workspace", default=None,
-                          help="Directory for cloned repos (default: ~/.aiorchestra/workspaces)")
-    dispatch.add_argument("--dry-run", action="store_true",
-                          help="Show plan without executing")
-    dispatch.add_argument("--verbose", "-v", action="store_true",
-                          help="Verbose logging")
+    dispatch.add_argument(
+        "--workspace",
+        default=None,
+        help="Directory for cloned repos (default: ~/.aiorchestra/workspaces)",
+    )
+    dispatch.add_argument("--dry-run", action="store_true", help="Show plan without executing")
+    dispatch.add_argument("--verbose", "-v", action="store_true", help="Verbose logging")
 
     return parser
 

--- a/aiorchestra/pipeline.py
+++ b/aiorchestra/pipeline.py
@@ -29,7 +29,9 @@ _DEFERRED = "deferred"
 def _has_changes(repo_root: str) -> bool:
     """Return True if the worktree has any uncommitted or staged changes."""
     result = run_command(
-        ["git", "status", "--porcelain"], cwd=repo_root, logger=log,
+        ["git", "status", "--porcelain"],
+        cwd=repo_root,
+        logger=log,
     )
     return bool(result.stdout.strip())
 
@@ -136,7 +138,9 @@ class Pipeline:
             if pid > 0:
                 # Parent — record child and move to next issue.
                 log.info(
-                    "Forked child %d for issue #%d", pid, issue["number"],
+                    "Forked child %d for issue #%d",
+                    pid,
+                    issue["number"],
                 )
                 children.append((pid, issue["number"]))
                 continue
@@ -188,7 +192,9 @@ class Pipeline:
             if exit_code != 0:
                 log.error(
                     "Child %d (issue #%d) exited with code %d",
-                    pid, number, exit_code,
+                    pid,
+                    number,
+                    exit_code,
                 )
                 failed.append(number)
             else:
@@ -300,9 +306,7 @@ class Pipeline:
             # Invariant 2: never proceed past implementation with zero file
             # changes.  Validation on an unmodified worktree is a false positive.
             if not _has_changes(ctx.repo_root):
-                log.error(
-                    "AI agent produced no file changes — aborting"
-                )
+                log.error("AI agent produced no file changes — aborting")
                 return False
 
             ok, validation_errors = validate(ctx.config, repo_root=ctx.repo_root)
@@ -400,7 +404,9 @@ class Pipeline:
                 ctx.issue["number"],
             )
             request_clarification(
-                ctx.repo, ctx.issue, result.clarification_message,
+                ctx.repo,
+                ctx.issue,
+                result.clarification_message,
             )
             return _DEFERRED
 

--- a/aiorchestra/stages/ci.py
+++ b/aiorchestra/stages/ci.py
@@ -51,8 +51,7 @@ def wait_for_ci(pr_url: str, config: PipelineConfig) -> FeedbackResult:
 
         failures = [c for c in checks if c.get("bucket") == "fail"]
         summary = "\n".join(
-            f"- {c['name']}: {c.get('state', 'unknown')} ({c.get('link', '')})"
-            for c in failures
+            f"- {c['name']}: {c.get('state', 'unknown')} ({c.get('link', '')})" for c in failures
         )
         log.warning("CI failed:\n%s", summary)
 

--- a/aiorchestra/stages/clarification.py
+++ b/aiorchestra/stages/clarification.py
@@ -42,7 +42,8 @@ def request_clarification(
 
     if comment_ok and label_ok:
         log.info(
-            "Issue #%d deferred — clarification requested", number,
+            "Issue #%d deferred — clarification requested",
+            number,
         )
     return comment_ok and label_ok
 

--- a/aiorchestra/stages/discover.py
+++ b/aiorchestra/stages/discover.py
@@ -82,17 +82,14 @@ def discover_issues(
         return []
 
     issues = [_normalize_issue(issue) for issue in data]
-    eligible_issues = [
-        issue for issue in issues if required_label in issue.get("labels", [])
-    ]
+    eligible_issues = [issue for issue in issues if required_label in issue.get("labels", [])]
     if not eligible_issues:
         log.error("No issues matched required agent label: %s", required_label)
         return []
 
     # Filter out issues that are already in progress or waiting on a human.
     ready_issues = [
-        issue for issue in eligible_issues
-        if not SKIP_LABELS.intersection(issue.get("labels", []))
+        issue for issue in eligible_issues if not SKIP_LABELS.intersection(issue.get("labels", []))
     ]
     skipped = len(eligible_issues) - len(ready_issues)
     if skipped:

--- a/aiorchestra/stages/labels.py
+++ b/aiorchestra/stages/labels.py
@@ -24,14 +24,15 @@ SKIP_LABELS: frozenset[str] = frozenset({LABEL_WORKING, LABEL_NEEDS_CLARIFICATIO
 def add_label(repo: str, issue_number: int, label: str) -> bool:
     """Add *label* to issue *issue_number*. Returns True on success."""
     result = run_command(
-        ["gh", "issue", "edit", str(issue_number), "--repo", repo,
-         "--add-label", label],
+        ["gh", "issue", "edit", str(issue_number), "--repo", repo, "--add-label", label],
         logger=log,
     )
     if result.returncode != 0:
         log.error(
             "Failed to add label '%s' to #%d: %s",
-            label, issue_number, result.stderr.strip(),
+            label,
+            issue_number,
+            result.stderr.strip(),
         )
         return False
     log.debug("Added label '%s' to #%d", label, issue_number)
@@ -41,14 +42,15 @@ def add_label(repo: str, issue_number: int, label: str) -> bool:
 def remove_label(repo: str, issue_number: int, label: str) -> bool:
     """Remove *label* from issue *issue_number*. Returns True on success."""
     result = run_command(
-        ["gh", "issue", "edit", str(issue_number), "--repo", repo,
-         "--remove-label", label],
+        ["gh", "issue", "edit", str(issue_number), "--repo", repo, "--remove-label", label],
         logger=log,
     )
     if result.returncode != 0:
         log.error(
             "Failed to remove label '%s' from #%d: %s",
-            label, issue_number, result.stderr.strip(),
+            label,
+            issue_number,
+            result.stderr.strip(),
         )
         return False
     log.debug("Removed label '%s' from #%d", label, issue_number)

--- a/aiorchestra/stages/prepare.py
+++ b/aiorchestra/stages/prepare.py
@@ -57,8 +57,7 @@ def _check_disk_space(workspace_root: Path) -> None:
     free_mb = usage.free // (1024 * 1024)
     if free_mb < MIN_DISK_MB:
         raise RuntimeError(
-            f"Insufficient disk space: {free_mb} MB free, "
-            f"need at least {MIN_DISK_MB} MB"
+            f"Insufficient disk space: {free_mb} MB free, need at least {MIN_DISK_MB} MB"
         )
     log.debug("Disk space OK: %d MB free", free_mb)
 

--- a/aiorchestra/stages/publish.py
+++ b/aiorchestra/stages/publish.py
@@ -23,9 +23,7 @@ def publish(
     # Invariant 3: never push a branch with zero commits ahead of the base.
     # Invariant 4: never create a PR with an empty diff.
     if not _has_commits_ahead(repo_root):
-        log.error(
-            "Nothing to publish — branch has no changes relative to main"
-        )
+        log.error("Nothing to publish — branch has no changes relative to main")
         return None
 
     if not _push_branch(branch, repo_root):
@@ -99,8 +97,7 @@ def _create_pr(repo: str, branch: str, issue: IssueData, repo_root: str) -> Publ
 
     log.info("Creating PR for issue #%d", issue["number"])
     result = run_command(
-        ["gh", "pr", "create", "--repo", repo, "--head", branch,
-         "--title", title, "--body", body],
+        ["gh", "pr", "create", "--repo", repo, "--head", branch, "--title", title, "--body", body],
         cwd=repo_root,
         logger=log,
     )

--- a/aiorchestra/stages/review.py
+++ b/aiorchestra/stages/review.py
@@ -29,7 +29,11 @@ def review(
     title = issue["title"] if issue else "unknown"
 
     prompt = render_template(
-        "review", repo_root=repo_root, number=number, title=title, diff=diff,
+        "review",
+        repo_root=repo_root,
+        number=number,
+        title=title,
+        diff=diff,
     )
 
     review_config = config.get("review", {})

--- a/tests/test_clarification.py
+++ b/tests/test_clarification.py
@@ -15,6 +15,7 @@ from aiorchestra.stages.labels import LABEL_WORKING
 # InvokeResult / parsing
 # ---------------------------------------------------------------------------
 
+
 def test_parse_clarification_detects_marker():
     text = "NEEDS_CLARIFICATION: Which database adapter should I use?"
     result = _parse_clarification(text)
@@ -53,9 +54,13 @@ def test_parse_clarification_requires_exact_marker():
 # discover: needs-clarification exclusion
 # ---------------------------------------------------------------------------
 
+
 def _completed_process(payload):
     return subprocess.CompletedProcess(
-        args=["gh"], returncode=0, stdout=json.dumps(payload), stderr="",
+        args=["gh"],
+        returncode=0,
+        stdout=json.dumps(payload),
+        stderr="",
     )
 
 
@@ -88,7 +93,11 @@ def test_discover_excludes_needs_clarification_issues(monkeypatch):
     )
 
     issues = discover_issues(
-        "owner/repo", "claude", agent_label="claude", retries=1, delay=0,
+        "owner/repo",
+        "claude",
+        agent_label="claude",
+        retries=1,
+        delay=0,
     )
 
     assert len(issues) == 1
@@ -117,7 +126,11 @@ def test_discover_returns_empty_when_all_need_clarification(monkeypatch):
     )
 
     issues = discover_issues(
-        "owner/repo", "claude", agent_label="claude", retries=1, delay=0,
+        "owner/repo",
+        "claude",
+        agent_label="claude",
+        retries=1,
+        delay=0,
     )
 
     assert issues == []
@@ -126,6 +139,7 @@ def test_discover_returns_empty_when_all_need_clarification(monkeypatch):
 # ---------------------------------------------------------------------------
 # clarification stage: comment + label
 # ---------------------------------------------------------------------------
+
 
 def test_request_clarification_posts_comment_and_label(monkeypatch):
     from aiorchestra.stages import clarification as clar_mod
@@ -186,6 +200,7 @@ def test_request_clarification_returns_false_on_comment_failure(monkeypatch):
 # Pipeline: end-to-end deferred flow
 # ---------------------------------------------------------------------------
 
+
 def test_pipeline_defers_issue_on_clarification(monkeypatch, tmp_path):
     """When the agent requests clarification, the pipeline should defer the
     issue (not fail) and continue to the next one."""
@@ -220,7 +235,8 @@ def test_pipeline_defers_issue_on_clarification(monkeypatch, tmp_path):
     monkeypatch.setattr("aiorchestra.pipeline.implement", fake_implement)
     monkeypatch.setattr("aiorchestra.pipeline._has_changes", lambda repo_root: True)
     monkeypatch.setattr(
-        "aiorchestra.pipeline.validate", lambda config, repo_root=None: (True, None),
+        "aiorchestra.pipeline.validate",
+        lambda config, repo_root=None: (True, None),
     )
     monkeypatch.setattr(
         "aiorchestra.pipeline.publish",
@@ -261,7 +277,9 @@ def test_pipeline_defers_issue_on_clarification(monkeypatch, tmp_path):
     assert ("implement", 20) in calls
     assert len(clarification_calls) == 1
     assert clarification_calls[0] == (
-        "owner/repo", 10, clarification_msg,
+        "owner/repo",
+        10,
+        clarification_msg,
     )
 
 
@@ -307,6 +325,7 @@ def test_pipeline_process_issue_returns_deferred(monkeypatch, tmp_path):
 # discover: agent-working exclusion
 # ---------------------------------------------------------------------------
 
+
 def test_discover_excludes_agent_working_issues(monkeypatch):
     from aiorchestra.stages.discover import discover_issues
 
@@ -346,7 +365,11 @@ def test_discover_excludes_agent_working_issues(monkeypatch):
     )
 
     issues = discover_issues(
-        "owner/repo", "claude", agent_label="claude", retries=1, delay=0,
+        "owner/repo",
+        "claude",
+        agent_label="claude",
+        retries=1,
+        delay=0,
     )
 
     assert len(issues) == 1
@@ -356,6 +379,7 @@ def test_discover_excludes_agent_working_issues(monkeypatch):
 # ---------------------------------------------------------------------------
 # Label lifecycle: _claim_and_process (sequential mode)
 # ---------------------------------------------------------------------------
+
 
 def test_sequential_mode_adds_and_removes_working_label(monkeypatch, tmp_path):
     """In sequential mode, _claim_and_process should add agent-working before
@@ -387,8 +411,9 @@ def test_sequential_mode_adds_and_removes_working_label(monkeypatch, tmp_path):
     monkeypatch.setattr("aiorchestra.pipeline._has_changes", lambda repo_root: True)
     monkeypatch.setattr(
         "aiorchestra.pipeline.implement",
-        lambda issue, config, prompt_name="implement", error_text=None, repo_root=None:
-            InvokeResult(success=True),
+        lambda issue, config, prompt_name="implement", error_text=None, repo_root=None: (
+            InvokeResult(success=True)
+        ),
     )
     monkeypatch.setattr(
         "aiorchestra.pipeline.validate",
@@ -442,8 +467,9 @@ def test_sequential_mode_removes_label_on_failure(monkeypatch, tmp_path):
     )
     monkeypatch.setattr(
         "aiorchestra.pipeline.implement",
-        lambda issue, config, prompt_name="implement", error_text=None, repo_root=None:
-            InvokeResult(success=False),
+        lambda issue, config, prompt_name="implement", error_text=None, repo_root=None: (
+            InvokeResult(success=False)
+        ),
     )
 
     pipeline = Pipeline(
@@ -464,6 +490,7 @@ def test_sequential_mode_removes_label_on_failure(monkeypatch, tmp_path):
 # ---------------------------------------------------------------------------
 # Parallel mode: fork-per-issue
 # ---------------------------------------------------------------------------
+
 
 def test_parallel_mode_forks_per_issue(monkeypatch, tmp_path):
     """In parallel mode, each issue gets its own child process."""

--- a/tests/test_discover.py
+++ b/tests/test_discover.py
@@ -89,6 +89,7 @@ def test_discover_issue_number_requires_matching_agent_label(monkeypatch):
 # discover_all_issues
 # ---------------------------------------------------------------------------
 
+
 def test_discover_all_groups_by_repo(monkeypatch):
     monkeypatch.setattr(
         "aiorchestra.stages.discover.run_command",

--- a/tests/test_dispatcher.py
+++ b/tests/test_dispatcher.py
@@ -9,6 +9,7 @@ from aiorchestra.dispatcher import Dispatcher
 # resolve_agent
 # ---------------------------------------------------------------------------
 
+
 def test_resolve_agent_explicit_claude():
     assert resolve_agent(["aiorchestra", "claude"]) == "claude"
 
@@ -48,6 +49,7 @@ def test_resolve_agent_empty_labels():
 # ---------------------------------------------------------------------------
 # Dispatcher
 # ---------------------------------------------------------------------------
+
 
 def test_dispatcher_no_issues_returns_zero(monkeypatch):
     monkeypatch.setattr(
@@ -160,6 +162,7 @@ def test_dispatcher_passes_config_and_flags(monkeypatch):
 # CLI dispatch subcommand
 # ---------------------------------------------------------------------------
 
+
 def test_cli_dispatch_defaults():
     parser = build_parser()
     args = parser.parse_args(["dispatch"])
@@ -174,14 +177,19 @@ def test_cli_dispatch_defaults():
 
 def test_cli_dispatch_with_flags():
     parser = build_parser()
-    args = parser.parse_args([
-        "dispatch",
-        "--owner", "myorg",
-        "--config", "custom.yaml",
-        "--workspace", "/tmp/ws",
-        "--dry-run",
-        "-v",
-    ])
+    args = parser.parse_args(
+        [
+            "dispatch",
+            "--owner",
+            "myorg",
+            "--config",
+            "custom.yaml",
+            "--workspace",
+            "/tmp/ws",
+            "--dry-run",
+            "-v",
+        ]
+    )
 
     assert args.owner == "myorg"
     assert args.config == "custom.yaml"
@@ -193,6 +201,7 @@ def test_cli_dispatch_with_flags():
 # ---------------------------------------------------------------------------
 # Pipeline.run(issues=...) — pre-supplied issues
 # ---------------------------------------------------------------------------
+
 
 def test_pipeline_run_with_presupplied_issues(monkeypatch, tmp_path):
     """Pipeline.run(issues=...) skips discovery and processes the given issues."""
@@ -216,6 +225,7 @@ def test_pipeline_run_with_presupplied_issues(monkeypatch, tmp_path):
 
     def fake_implement(issue, config, prompt_name="implement", error_text=None, repo_root=None):
         from aiorchestra.ai.claude import InvokeResult
+
         calls.append(("implement", issue["number"]))
         return InvokeResult(success=True)
 

--- a/tests/test_pipeline.py
+++ b/tests/test_pipeline.py
@@ -156,6 +156,7 @@ def test_ci_fix_revalidates_and_republishes(monkeypatch, tmp_path):
 # Invariant tests
 # ---------------------------------------------------------------------------
 
+
 def test_no_changes_after_implement_aborts_immediately(monkeypatch, tmp_path):
     """Invariant 2: never proceed past implementation with zero file changes.
 


### PR DESCRIPTION
## Summary
This PR applies code formatting standards across the codebase using Ruff and adds automated linting checks to the CI pipeline.

## Key Changes

**Code Formatting:**
- Reformatted function arguments and parameters to follow consistent line-breaking conventions
- Aligned multi-line function calls and definitions for improved readability
- Standardized spacing in dictionaries and list comprehensions
- Consolidated long string concatenations into single lines where appropriate
- Fixed alignment of inline comments in dictionaries

**CI/Linting:**
- Added a new `lint` job to `.github/workflows/ci.yml` that runs before tests
- Configured Ruff to check code style with `ruff check .`
- Configured Ruff to verify formatting with `ruff format --check .`
- Uses Python 3.12 for linting checks

**Files Modified:**
- `aiorchestra/cli.py` - Reformatted argument definitions
- `aiorchestra/pipeline.py` - Reformatted function calls and log statements
- `aiorchestra/stages/labels.py` - Reformatted command arrays and error logging
- `aiorchestra/stages/discover.py` - Simplified list comprehensions
- `aiorchestra/stages/publish.py` - Consolidated long strings
- `aiorchestra/stages/clarification.py` - Reformatted log calls
- `aiorchestra/stages/prepare.py` - Consolidated error messages
- `aiorchestra/stages/review.py` - Reformatted template rendering call
- `aiorchestra/stages/ci.py` - Reformatted list comprehension
- `aiorchestra/ai/claude.py` - Reformatted regex pattern and error messages
- `aiorchestra/_logging.py` - Aligned dictionary values and consolidated string formatting
- Multiple test files - Added blank lines between test sections and reformatted assertions

## Implementation Details
- All changes are formatting-only; no functional logic was modified
- The linting job runs on every PR and commit to maintain code quality standards
- Ruff is configured via the project's `[dev]` dependencies

https://claude.ai/code/session_011UYQ7hTWMA2Dhxb1cToQxc