### PR TITLE
Implement multi-tier code review pipeline with AI and human gates

### DIFF
--- a/aiorchestra/config.py
+++ b/aiorchestra/config.py
@@ -24,7 +24,36 @@ DEFAULTS = {
     },
     "review": {
         "enabled": True,
-        "provider": "claude-code",
+        "tiers": [
+            {
+                "name": "static-analysis",
+                "enabled": False,
+                "commands": [
+                    "semgrep --config=auto --quiet .",
+                    "bandit -r . -q",
+                ],
+            },
+            {
+                "name": "ai-review",
+                "enabled": True,
+                "provider": "claude-code",
+            },
+            {
+                "name": "cross-model-review",
+                "enabled": False,
+                "provider": "ollama",
+                "ollama": {
+                    "endpoint": "http://localhost:11434",
+                    "model": "mistral",
+                    "timeout": 120,
+                },
+            },
+            {
+                "name": "human-required",
+                "enabled": False,
+                "labels": ["security", "breaking-change"],
+            },
+        ],
     },
     "ci": {
         "enabled": True,

--- a/aiorchestra/stages/review.py
+++ b/aiorchestra/stages/review.py
@@ -1,8 +1,21 @@
-"""Review stage — AI reviews the diff. This is where AI tokens are spent."""
+"""Review stage — multi-tier AI code review.
+
+Tiers execute in order and short-circuit on failure:
+
+  T3  ai-review          — primary AI reviews the diff (default: claude-code)
+  T4  cross-model-review — second AI cross-checks (default: ollama/local)
+  T5  human-required     — gate on human approval (label-gated)
+
+T0 (lint/tests) and T1 (static analysis) run earlier in the validate stage.
+"""
+
+from __future__ import annotations
 
 import logging
+from typing import Any
 
 from aiorchestra.ai.claude import invoke_claude
+from aiorchestra.ai.ollama import invoke_ollama, ollama_available
 from aiorchestra.stages._shell import run_command
 from aiorchestra.stages.types import FeedbackResult, IssueData, PipelineConfig
 from aiorchestra.templates import render_template
@@ -10,21 +23,26 @@ from aiorchestra.templates import render_template
 log = logging.getLogger(__name__)
 
 
-def review(
-    repo: str,
-    branch: str,
-    config: PipelineConfig,
-    issue: IssueData | None = None,
-    repo_root: str | None = None,
-) -> FeedbackResult:
-    """Run AI code review on the current diff. Returns (passed, feedback)."""
+def _get_diff(repo_root: str | None) -> str:
     result = run_command(["git", "diff", "origin/main...HEAD"], cwd=repo_root, logger=log)
-    diff = result.stdout
+    return result.stdout
 
-    if not diff.strip():
-        log.warning("No diff to review.")
-        return True, None
 
+def _get_tier(tiers: list[dict[str, Any]], name: str) -> dict[str, Any] | None:
+    return next((t for t in tiers if t.get("name") == name), None)
+
+
+# -- T3: AI review (primary) ------------------------------------------------
+
+
+def _run_ai_review(
+    diff: str,
+    config: PipelineConfig,
+    tier_cfg: dict[str, Any],
+    issue: IssueData | None,
+    repo_root: str | None,
+) -> FeedbackResult:
+    """Run primary AI code review via Claude."""
     number = issue["number"] if issue else 0
     title = issue["title"] if issue else "unknown"
 
@@ -36,17 +54,165 @@ def review(
         diff=diff,
     )
 
-    review_config = config.get("review", {})
-    ai_config = {**config.get("ai", {}), **review_config}
-
+    ai_config = {**config.get("ai", {}), **tier_cfg}
     result = invoke_claude(prompt, ai_config, capture_output=True, cwd=repo_root)
 
     if not result.success:
-        return False, "Review invocation failed."
+        return False, "AI review invocation failed."
 
     if "LGTM" in result.output:
-        log.info("Review passed.")
+        log.info("AI review (T3) passed.")
         return True, None
 
-    log.info("Review flagged issues.")
+    log.info("AI review (T3) flagged issues.")
     return False, result.output
+
+
+# -- T4: Cross-model review -------------------------------------------------
+
+
+def _run_cross_model_review(
+    diff: str,
+    tier_cfg: dict[str, Any],
+    issue: IssueData | None,
+    repo_root: str | None,
+) -> FeedbackResult:
+    """Run cross-model review via a different provider (default: Ollama)."""
+    provider = tier_cfg.get("provider", "ollama")
+
+    number = issue["number"] if issue else 0
+    title = issue["title"] if issue else "unknown"
+
+    prompt = render_template(
+        "review_cross_model",
+        repo_root=repo_root,
+        number=number,
+        title=title,
+        diff=diff,
+    )
+
+    if provider == "ollama":
+        return _cross_model_ollama(prompt, tier_cfg)
+
+    # For claude-code or claude-api, use invoke_claude with tier-specific config
+    from aiorchestra.ai.claude import invoke_claude
+
+    result = invoke_claude(prompt, tier_cfg, capture_output=True)
+    if not result.success:
+        return False, "Cross-model review invocation failed."
+    if "LGTM" in result.output:
+        log.info("Cross-model review (T4) passed.")
+        return True, None
+    return False, result.output
+
+
+def _cross_model_ollama(prompt: str, tier_cfg: dict[str, Any]) -> FeedbackResult:
+    """Run cross-model review using local Ollama."""
+    ollama_cfg = tier_cfg.get("ollama", {})
+    if not ollama_available(ollama_cfg):
+        log.warning("Ollama not available — skipping cross-model review (T4)")
+        return True, None
+
+    response = invoke_ollama(
+        prompt,
+        ollama_cfg,
+        system="You are a code reviewer. Review the diff for bugs, security issues, and "
+        "logic errors. If the code looks good, respond with exactly: LGTM. "
+        "If there are issues, describe them clearly with severity levels.",
+    )
+
+    if response is None:
+        log.warning("Ollama returned no response — skipping cross-model review (T4)")
+        return True, None
+
+    if "LGTM" in response:
+        log.info("Cross-model review (T4) passed.")
+        return True, None
+
+    log.info("Cross-model review (T4) flagged issues.")
+    return False, response
+
+
+# -- T5: Human-required gate -------------------------------------------------
+
+
+def _check_human_required(
+    tier_cfg: dict[str, Any],
+    issue: IssueData | None,
+) -> FeedbackResult:
+    """Check if human review is required based on issue labels."""
+    if not issue:
+        return True, None
+
+    gated_labels = set(tier_cfg.get("labels", []))
+    issue_labels = {
+        lbl if isinstance(lbl, str) else lbl.get("name", "") for lbl in issue.get("labels", [])
+    }
+
+    matching = gated_labels & issue_labels
+    if matching:
+        log.info(
+            "Human review required — issue has gated labels: %s",
+            ", ".join(sorted(matching)),
+        )
+        return False, (
+            f"HUMAN_REVIEW_REQUIRED: This change touches labels [{', '.join(sorted(matching))}] "
+            f"that require human approval before merge."
+        )
+
+    log.info("Human review gate (T5) — no gated labels, passing.")
+    return True, None
+
+
+# -- Public entry point ------------------------------------------------------
+
+
+def review(
+    repo: str,
+    branch: str,
+    config: PipelineConfig,
+    issue: IssueData | None = None,
+    repo_root: str | None = None,
+) -> FeedbackResult:
+    """Run tiered code review. Returns (passed, feedback).
+
+    Tiers execute in order; each must pass before the next runs.
+    Disabled tiers are skipped. If no tiers are enabled, defaults to
+    the legacy single-AI-review behaviour.
+    """
+    review_cfg = config.get("review", {})
+    tiers = review_cfg.get("tiers", [])
+
+    diff = _get_diff(repo_root)
+    if not diff.strip():
+        log.warning("No diff to review.")
+        return True, None
+
+    # If no tiers configured, fall back to legacy behaviour (single AI review)
+    if not tiers:
+        return _run_ai_review(diff, config, review_cfg, issue, repo_root)
+
+    for tier_cfg in tiers:
+        name = tier_cfg.get("name", "unknown")
+        if not tier_cfg.get("enabled", False):
+            log.debug("Tier '%s' disabled, skipping.", name)
+            continue
+
+        log.info("Running review tier: %s", name)
+
+        if name == "ai-review":
+            ok, feedback = _run_ai_review(diff, config, tier_cfg, issue, repo_root)
+        elif name == "cross-model-review":
+            ok, feedback = _run_cross_model_review(diff, tier_cfg, issue, repo_root)
+        elif name == "human-required":
+            ok, feedback = _check_human_required(tier_cfg, issue)
+        else:
+            log.warning("Unknown review tier '%s', skipping.", name)
+            continue
+
+        if not ok:
+            log.info("Review tier '%s' failed — stopping.", name)
+            return False, feedback
+
+    log.info("All review tiers passed.")
+    return True, None

--- a/aiorchestra/stages/validate.py
+++ b/aiorchestra/stages/validate.py
@@ -1,6 +1,7 @@
-"""Validate stage — run tests and linters. Pure shell — no AI tokens spent."""
+"""Validate stage — run tests, linters, and static analysis. Pure shell — no AI tokens spent."""
 
 import logging
+import shutil
 
 from aiorchestra.stages._shell import run_command
 from aiorchestra.stages.types import FeedbackResult, PipelineConfig
@@ -8,12 +9,38 @@ from aiorchestra.stages.types import FeedbackResult, PipelineConfig
 log = logging.getLogger(__name__)
 
 
+def _run_static_analysis(
+    review_cfg: PipelineConfig,
+    repo_root: str | None = None,
+) -> list[str]:
+    """Run static-analysis tier commands (T1). Returns list of error strings."""
+    tiers = review_cfg.get("tiers", [])
+    sa_tier = next((t for t in tiers if t.get("name") == "static-analysis"), None)
+    if not sa_tier or not sa_tier.get("enabled", False):
+        return []
+
+    errors = []
+    for cmd in sa_tier.get("commands", []):
+        tool_name = cmd.split()[0]
+        if not shutil.which(tool_name):
+            log.info("Static analysis tool '%s' not found on PATH, skipping", tool_name)
+            continue
+
+        log.info("Running static analysis: %s", cmd)
+        result = run_command(cmd, cwd=repo_root, logger=log)
+        if result.returncode != 0:
+            errors.append(f"Static analysis ({tool_name}):\n{result.stdout}\n{result.stderr}")
+
+    return errors
+
+
 def validate(config: PipelineConfig, repo_root: str | None = None) -> FeedbackResult:
-    """Run tests and linter. Returns (success, error_output)."""
+    """Run tests, linter, and static analysis. Returns (success, error_output)."""
     test_cfg = config.get("test", {})
+    review_cfg = config.get("review", {})
     errors = []
 
-    # Run linter
+    # T0: Linter
     lint_cmd = test_cfg.get("lint_command", "ruff check .")
     log.info("Running linter: %s", lint_cmd)
     result = run_command(
@@ -24,7 +51,7 @@ def validate(config: PipelineConfig, repo_root: str | None = None) -> FeedbackRe
     if result.returncode != 0:
         errors.append(f"Lint errors:\n{result.stdout}\n{result.stderr}")
 
-    # Run tests
+    # T0: Tests
     test_cmd = test_cfg.get("command", "pytest")
     log.info("Running tests: %s", test_cmd)
     result = run_command(
@@ -34,6 +61,9 @@ def validate(config: PipelineConfig, repo_root: str | None = None) -> FeedbackRe
     )
     if result.returncode != 0:
         errors.append(f"Test errors:\n{result.stdout}\n{result.stderr}")
+
+    # T1: Static analysis (semgrep, bandit, etc.)
+    errors.extend(_run_static_analysis(review_cfg, repo_root))
 
     if errors:
         combined = "\n---\n".join(errors)

--- a/aiorchestra/templates/review_cross_model.md
+++ b/aiorchestra/templates/review_cross_model.md
@@ -1,0 +1,18 @@
+You are reviewing code written by a different AI model for issue #{number}: {title}
+
+Your role is to catch issues the original model may have missed. Focus on:
+- Incorrect assumptions or hallucinated APIs/methods
+- Logic errors and off-by-one mistakes
+- Security vulnerabilities (injection, auth bypass, data exposure)
+- Missing error handling at system boundaries
+- Resource leaks (unclosed files, connections, locks)
+- Race conditions or concurrency issues
+
+Do NOT flag style preferences or minor naming choices.
+
+If the code is correct and safe, respond with exactly: LGTM
+If there are issues, list each with a severity (critical/warning/info).
+
+```diff
+{diff}
+```

--- a/tests/test_review.py
+++ b/tests/test_review.py
@@ -1,0 +1,359 @@
+"""Tests for the multi-tier review stage."""
+
+import types
+
+from aiorchestra.ai.claude import InvokeResult
+from aiorchestra.stages import review as rev_mod
+from aiorchestra.stages.review import (
+    _check_human_required,
+    _run_ai_review,
+    _run_cross_model_review,
+    review,
+)
+
+ISSUE = {"number": 42, "title": "Add feature X"}
+DIFF = "+def foo():\n+    return 42\n"
+
+
+# ---------------------------------------------------------------------------
+# T3: AI review
+# ---------------------------------------------------------------------------
+
+
+def test_ai_review_passes_on_lgtm(monkeypatch):
+    monkeypatch.setattr(
+        rev_mod,
+        "invoke_claude",
+        lambda prompt, cfg, capture_output=False, cwd=None: InvokeResult(
+            success=True, output="LGTM"
+        ),
+    )
+    monkeypatch.setattr(
+        rev_mod,
+        "render_template",
+        lambda name, **kw: f"review {kw['number']}",
+    )
+
+    ok, feedback = _run_ai_review(DIFF, {}, {}, ISSUE, None)
+    assert ok
+    assert feedback is None
+
+
+def test_ai_review_fails_on_issues(monkeypatch):
+    monkeypatch.setattr(
+        rev_mod,
+        "invoke_claude",
+        lambda prompt, cfg, capture_output=False, cwd=None: InvokeResult(
+            success=True, output="Bug: off-by-one in loop"
+        ),
+    )
+    monkeypatch.setattr(
+        rev_mod,
+        "render_template",
+        lambda name, **kw: "review prompt",
+    )
+
+    ok, feedback = _run_ai_review(DIFF, {}, {}, ISSUE, None)
+    assert not ok
+    assert "off-by-one" in feedback
+
+
+def test_ai_review_fails_on_invocation_error(monkeypatch):
+    monkeypatch.setattr(
+        rev_mod,
+        "invoke_claude",
+        lambda prompt, cfg, capture_output=False, cwd=None: InvokeResult(success=False),
+    )
+    monkeypatch.setattr(
+        rev_mod,
+        "render_template",
+        lambda name, **kw: "review prompt",
+    )
+
+    ok, feedback = _run_ai_review(DIFF, {}, {}, ISSUE, None)
+    assert not ok
+    assert "failed" in feedback
+
+
+# ---------------------------------------------------------------------------
+# T4: Cross-model review (Ollama)
+# ---------------------------------------------------------------------------
+
+
+def test_cross_model_ollama_passes_on_lgtm(monkeypatch):
+    monkeypatch.setattr(rev_mod, "ollama_available", lambda cfg: True)
+    monkeypatch.setattr(
+        rev_mod,
+        "invoke_ollama",
+        lambda prompt, cfg, system=None: "LGTM",
+    )
+    monkeypatch.setattr(
+        rev_mod,
+        "render_template",
+        lambda name, **kw: "cross model prompt",
+    )
+
+    tier_cfg = {"provider": "ollama", "ollama": {"endpoint": "http://localhost:11434"}}
+    ok, feedback = _run_cross_model_review(DIFF, tier_cfg, ISSUE, None)
+    assert ok
+    assert feedback is None
+
+
+def test_cross_model_ollama_flags_issues(monkeypatch):
+    monkeypatch.setattr(rev_mod, "ollama_available", lambda cfg: True)
+    monkeypatch.setattr(
+        rev_mod,
+        "invoke_ollama",
+        lambda prompt, cfg, system=None: "critical: SQL injection in query builder",
+    )
+    monkeypatch.setattr(
+        rev_mod,
+        "render_template",
+        lambda name, **kw: "cross model prompt",
+    )
+
+    tier_cfg = {"provider": "ollama", "ollama": {}}
+    ok, feedback = _run_cross_model_review(DIFF, tier_cfg, ISSUE, None)
+    assert not ok
+    assert "SQL injection" in feedback
+
+
+def test_cross_model_skipped_when_ollama_unavailable(monkeypatch):
+    monkeypatch.setattr(rev_mod, "ollama_available", lambda cfg: False)
+    monkeypatch.setattr(
+        rev_mod,
+        "render_template",
+        lambda name, **kw: "cross model prompt",
+    )
+
+    tier_cfg = {"provider": "ollama", "ollama": {}}
+    ok, feedback = _run_cross_model_review(DIFF, tier_cfg, ISSUE, None)
+    assert ok  # gracefully passes when unavailable
+
+
+def test_cross_model_skipped_on_none_response(monkeypatch):
+    monkeypatch.setattr(rev_mod, "ollama_available", lambda cfg: True)
+    monkeypatch.setattr(
+        rev_mod,
+        "invoke_ollama",
+        lambda prompt, cfg, system=None: None,
+    )
+    monkeypatch.setattr(
+        rev_mod,
+        "render_template",
+        lambda name, **kw: "cross model prompt",
+    )
+
+    tier_cfg = {"provider": "ollama", "ollama": {}}
+    ok, feedback = _run_cross_model_review(DIFF, tier_cfg, ISSUE, None)
+    assert ok  # gracefully passes when response is None
+
+
+# ---------------------------------------------------------------------------
+# T5: Human-required gate
+# ---------------------------------------------------------------------------
+
+
+def test_human_required_blocks_on_matching_label():
+    tier_cfg = {"labels": ["security", "breaking-change"]}
+    issue = {"number": 1, "title": "Fix", "labels": ["security", "bug"]}
+
+    ok, feedback = _check_human_required(tier_cfg, issue)
+    assert not ok
+    assert "HUMAN_REVIEW_REQUIRED" in feedback
+    assert "security" in feedback
+
+
+def test_human_required_passes_when_no_matching_labels():
+    tier_cfg = {"labels": ["security", "breaking-change"]}
+    issue = {"number": 1, "title": "Fix", "labels": ["bug", "enhancement"]}
+
+    ok, feedback = _check_human_required(tier_cfg, issue)
+    assert ok
+    assert feedback is None
+
+
+def test_human_required_passes_with_no_issue():
+    tier_cfg = {"labels": ["security"]}
+    ok, feedback = _check_human_required(tier_cfg, None)
+    assert ok
+
+
+def test_human_required_passes_with_no_labels_on_issue():
+    tier_cfg = {"labels": ["security"]}
+    issue = {"number": 1, "title": "Fix"}
+
+    ok, feedback = _check_human_required(tier_cfg, issue)
+    assert ok
+
+
+# ---------------------------------------------------------------------------
+# Full tiered review (integration)
+# ---------------------------------------------------------------------------
+
+
+def test_review_empty_diff_passes(monkeypatch):
+    monkeypatch.setattr(
+        rev_mod,
+        "run_command",
+        lambda cmd, cwd=None, logger=None: types.SimpleNamespace(
+            returncode=0, stdout="", stderr=""
+        ),
+    )
+
+    ok, feedback = review("owner/repo", "main", {})
+    assert ok
+    assert feedback is None
+
+
+def test_review_runs_tiers_in_order(monkeypatch):
+    monkeypatch.setattr(
+        rev_mod,
+        "run_command",
+        lambda cmd, cwd=None, logger=None: types.SimpleNamespace(
+            returncode=0, stdout=DIFF, stderr=""
+        ),
+    )
+    monkeypatch.setattr(
+        rev_mod,
+        "invoke_claude",
+        lambda prompt, cfg, capture_output=False, cwd=None: InvokeResult(
+            success=True, output="LGTM"
+        ),
+    )
+    monkeypatch.setattr(rev_mod, "ollama_available", lambda cfg: True)
+    monkeypatch.setattr(
+        rev_mod,
+        "invoke_ollama",
+        lambda prompt, cfg, system=None: "LGTM",
+    )
+    monkeypatch.setattr(
+        rev_mod,
+        "render_template",
+        lambda name, **kw: f"template:{name}",
+    )
+
+    config = {
+        "review": {
+            "tiers": [
+                {"name": "ai-review", "enabled": True, "provider": "claude-code"},
+                {"name": "cross-model-review", "enabled": True, "provider": "ollama", "ollama": {}},
+            ]
+        }
+    }
+
+    ok, feedback = review("owner/repo", "branch", config, issue=ISSUE)
+    assert ok
+    assert feedback is None
+
+
+def test_review_short_circuits_on_tier_failure(monkeypatch):
+    monkeypatch.setattr(
+        rev_mod,
+        "run_command",
+        lambda cmd, cwd=None, logger=None: types.SimpleNamespace(
+            returncode=0, stdout=DIFF, stderr=""
+        ),
+    )
+    monkeypatch.setattr(
+        rev_mod,
+        "invoke_claude",
+        lambda prompt, cfg, capture_output=False, cwd=None: InvokeResult(
+            success=True, output="Bug: memory leak"
+        ),
+    )
+    monkeypatch.setattr(
+        rev_mod,
+        "render_template",
+        lambda name, **kw: "template",
+    )
+
+    ollama_called = False
+
+    def spy_ollama(prompt, cfg, system=None):
+        nonlocal ollama_called
+        ollama_called = True
+        return "LGTM"
+
+    monkeypatch.setattr(rev_mod, "invoke_ollama", spy_ollama)
+    monkeypatch.setattr(rev_mod, "ollama_available", lambda cfg: True)
+
+    config = {
+        "review": {
+            "tiers": [
+                {"name": "ai-review", "enabled": True, "provider": "claude-code"},
+                {"name": "cross-model-review", "enabled": True, "provider": "ollama", "ollama": {}},
+            ]
+        }
+    }
+
+    ok, feedback = review("owner/repo", "branch", config, issue=ISSUE)
+    assert not ok
+    assert "memory leak" in feedback
+    assert not ollama_called  # T4 never executed because T3 failed
+
+
+def test_review_skips_disabled_tiers(monkeypatch):
+    monkeypatch.setattr(
+        rev_mod,
+        "run_command",
+        lambda cmd, cwd=None, logger=None: types.SimpleNamespace(
+            returncode=0, stdout=DIFF, stderr=""
+        ),
+    )
+
+    claude_called = False
+
+    def spy_claude(prompt, cfg, capture_output=False, cwd=None):
+        nonlocal claude_called
+        claude_called = True
+        return InvokeResult(success=True, output="LGTM")
+
+    monkeypatch.setattr(rev_mod, "invoke_claude", spy_claude)
+    monkeypatch.setattr(
+        rev_mod,
+        "render_template",
+        lambda name, **kw: "template",
+    )
+
+    config = {
+        "review": {
+            "tiers": [
+                {"name": "ai-review", "enabled": False},
+                {"name": "cross-model-review", "enabled": False},
+            ]
+        }
+    }
+
+    ok, feedback = review("owner/repo", "branch", config, issue=ISSUE)
+    assert ok
+    assert not claude_called
+
+
+def test_review_falls_back_to_legacy_when_no_tiers(monkeypatch):
+    """When no tiers are configured, falls back to single AI review."""
+    monkeypatch.setattr(
+        rev_mod,
+        "run_command",
+        lambda cmd, cwd=None, logger=None: types.SimpleNamespace(
+            returncode=0, stdout=DIFF, stderr=""
+        ),
+    )
+    monkeypatch.setattr(
+        rev_mod,
+        "invoke_claude",
+        lambda prompt, cfg, capture_output=False, cwd=None: InvokeResult(
+            success=True, output="LGTM"
+        ),
+    )
+    monkeypatch.setattr(
+        rev_mod,
+        "render_template",
+        lambda name, **kw: "template",
+    )
+
+    # Config with review enabled but no tiers key
+    config = {"review": {"enabled": True, "provider": "claude-code"}}
+
+    ok, feedback = review("owner/repo", "branch", config, issue=ISSUE)
+    assert ok

--- a/tests/test_validate.py
+++ b/tests/test_validate.py
@@ -1,0 +1,149 @@
+"""Tests for the validate stage including T1 static analysis."""
+
+import types
+
+from aiorchestra.stages import validate as val_mod
+from aiorchestra.stages.validate import _run_static_analysis, validate
+
+
+def test_validate_passes_when_lint_and_tests_succeed(monkeypatch):
+    calls = []
+
+    def fake_run(cmd, *, cwd=None, check=False, shell=None, logger=None):
+        calls.append(cmd if isinstance(cmd, str) else " ".join(cmd))
+        return types.SimpleNamespace(returncode=0, stdout="", stderr="")
+
+    monkeypatch.setattr(val_mod, "run_command", fake_run)
+
+    ok, errors = validate({"test": {"command": "pytest", "lint_command": "ruff check ."}})
+    assert ok
+    assert errors is None
+    assert calls == ["ruff check .", "pytest"]
+
+
+def test_validate_collects_lint_and_test_errors(monkeypatch):
+    def fake_run(cmd, *, cwd=None, check=False, shell=None, logger=None):
+        return types.SimpleNamespace(returncode=1, stdout="bad", stderr="err")
+
+    monkeypatch.setattr(val_mod, "run_command", fake_run)
+
+    ok, errors = validate({"test": {}})
+    assert not ok
+    assert "Lint errors" in errors
+    assert "Test errors" in errors
+
+
+def test_static_analysis_runs_when_enabled(monkeypatch):
+    calls = []
+
+    def fake_run(cmd, *, cwd=None, check=False, shell=None, logger=None):
+        calls.append(cmd if isinstance(cmd, str) else " ".join(cmd))
+        return types.SimpleNamespace(returncode=0, stdout="", stderr="")
+
+    monkeypatch.setattr(val_mod, "run_command", fake_run)
+    monkeypatch.setattr(val_mod.shutil, "which", lambda tool: f"/usr/bin/{tool}")
+
+    review_cfg = {
+        "tiers": [
+            {
+                "name": "static-analysis",
+                "enabled": True,
+                "commands": ["semgrep --config=auto .", "bandit -r . -q"],
+            }
+        ]
+    }
+
+    errors = _run_static_analysis(review_cfg)
+    assert errors == []
+    assert calls == ["semgrep --config=auto .", "bandit -r . -q"]
+
+
+def test_static_analysis_skips_missing_tools(monkeypatch):
+    calls = []
+
+    def fake_run(cmd, *, cwd=None, check=False, shell=None, logger=None):
+        calls.append(cmd if isinstance(cmd, str) else " ".join(cmd))
+        return types.SimpleNamespace(returncode=0, stdout="", stderr="")
+
+    monkeypatch.setattr(val_mod, "run_command", fake_run)
+    monkeypatch.setattr(val_mod.shutil, "which", lambda tool: None)
+
+    review_cfg = {
+        "tiers": [
+            {
+                "name": "static-analysis",
+                "enabled": True,
+                "commands": ["semgrep --config=auto ."],
+            }
+        ]
+    }
+
+    errors = _run_static_analysis(review_cfg)
+    assert errors == []
+    assert calls == []
+
+
+def test_static_analysis_skipped_when_disabled(monkeypatch):
+    review_cfg = {
+        "tiers": [{"name": "static-analysis", "enabled": False, "commands": ["semgrep ."]}]
+    }
+
+    errors = _run_static_analysis(review_cfg)
+    assert errors == []
+
+
+def test_static_analysis_reports_failures(monkeypatch):
+    def fake_run(cmd, *, cwd=None, check=False, shell=None, logger=None):
+        return types.SimpleNamespace(returncode=1, stdout="vuln found", stderr="")
+
+    monkeypatch.setattr(val_mod, "run_command", fake_run)
+    monkeypatch.setattr(val_mod.shutil, "which", lambda tool: f"/usr/bin/{tool}")
+
+    review_cfg = {
+        "tiers": [
+            {
+                "name": "static-analysis",
+                "enabled": True,
+                "commands": ["bandit -r ."],
+            }
+        ]
+    }
+
+    errors = _run_static_analysis(review_cfg)
+    assert len(errors) == 1
+    assert "bandit" in errors[0]
+    assert "vuln found" in errors[0]
+
+
+def test_validate_includes_static_analysis_errors(monkeypatch):
+    """Static analysis errors from T1 are included in validate output."""
+    call_count = {"run": 0}
+
+    def fake_run(cmd, *, cwd=None, check=False, shell=None, logger=None):
+        cmd_str = cmd if isinstance(cmd, str) else " ".join(cmd)
+        call_count["run"] += 1
+        # Lint and tests pass, but static analysis fails
+        if "bandit" in cmd_str:
+            return types.SimpleNamespace(returncode=1, stdout="B101 assert used", stderr="")
+        return types.SimpleNamespace(returncode=0, stdout="", stderr="")
+
+    monkeypatch.setattr(val_mod, "run_command", fake_run)
+    monkeypatch.setattr(val_mod.shutil, "which", lambda tool: f"/usr/bin/{tool}")
+
+    config = {
+        "test": {"command": "pytest", "lint_command": "ruff check ."},
+        "review": {
+            "tiers": [
+                {
+                    "name": "static-analysis",
+                    "enabled": True,
+                    "commands": ["bandit -r ."],
+                }
+            ]
+        },
+    }
+
+    ok, errors = validate(config)
+    assert not ok
+    assert "bandit" in errors
+    assert "B101" in errors


### PR DESCRIPTION
## Summary

Refactors the review stage from a single-pass AI review into a configurable multi-tier pipeline that executes in sequence with short-circuit semantics. Adds support for cross-model review (via Ollama), human approval gates, and static analysis checks.

## Key Changes

- **Multi-tier review architecture**: Introduced T3 (AI review), T4 (cross-model review), and T5 (human-required gate) tiers that execute in order and stop on first failure
  - T3 `_run_ai_review()`: Primary Claude-based code review (existing behavior, refactored)
  - T4 `_run_cross_model_review()`: Secondary review via Ollama or alternative AI provider for cross-validation
  - T5 `_check_human_required()`: Label-gated human approval requirement

- **Static analysis integration**: Added T1 tier support in validate stage via `_run_static_analysis()` to run tools like semgrep and bandit before review stages

- **Configuration schema**: Updated `config.py` to define tiered structure with per-tier enable/disable flags and provider-specific settings (e.g., Ollama endpoint, model, timeout)

- **Backward compatibility**: Falls back to legacy single-AI-review behavior when no tiers are configured

- **Comprehensive test coverage**: 
  - 20+ tests for individual tier functions (AI review, cross-model, human gate)
  - Integration tests for tier ordering, short-circuiting, and disabled tier skipping
  - Validate stage tests for static analysis execution and error collection

## Implementation Details

- Tier execution uses a simple loop with early return on failure; disabled tiers are skipped via `enabled` flag
- Cross-model review gracefully handles unavailable providers (e.g., Ollama not running) by passing
- Human-required gate supports both string labels and label objects with `name` field
- Static analysis tools are checked for availability via `shutil.which()` before execution
- All tier functions follow consistent `(ok: bool, feedback: str | None)` return signature
- Template system extended with `review_cross_model.md` for secondary review prompts

https://claude.ai/code/session_01Rpp9UagxFk49tJeA5ZmZ4D