### PR TITLE
Fix #29: Detect existing PR before creating a new one in publish stage

### DIFF
--- a/aiorchestra/stages/publish.py
+++ b/aiorchestra/stages/publish.py
@@ -90,8 +90,25 @@ def _push_branch(branch: str, repo_root: str) -> bool:
     return True
 
 
+def _find_existing_pr(repo: str, branch: str, repo_root: str) -> str | None:
+    """Return the URL of an open PR for *branch*, or ``None`` if none exists."""
+    result = run_command(
+        ["gh", "pr", "view", "--repo", repo, "--head", branch, "--json", "url", "--jq", ".url"],
+        cwd=repo_root,
+        logger=log,
+    )
+    if result.returncode == 0 and result.stdout.strip():
+        return result.stdout.strip()
+    return None
+
+
 def _create_pr(repo: str, branch: str, issue: IssueData, repo_root: str) -> PublishResult:
-    """Create a PR for the pushed branch."""
+    """Create a PR for the pushed branch, or return the existing one."""
+    existing = _find_existing_pr(repo, branch, repo_root)
+    if existing:
+        log.info("PR already exists for branch %s: %s", branch, existing)
+        return existing
+
     title = f"Fix #{issue['number']}: {issue['title']}"
     body = f"Automated implementation for #{issue['number']}.\n\nCloses #{issue['number']}"
 

--- a/tests/test_publish.py
+++ b/tests/test_publish.py
@@ -1,0 +1,146 @@
+"""Tests for the publish stage — PR creation and existing-PR detection."""
+
+import types
+
+from aiorchestra.stages import publish as pub_mod
+from aiorchestra.stages.publish import _create_pr, _find_existing_pr, publish
+
+ISSUE = {"number": 24, "title": "Add multi-level verbose logging"}
+REPO = "owner/repo"
+BRANCH = "claude/24"
+REPO_ROOT = "/tmp/fake-repo"
+
+
+def _make_result(returncode=0, stdout="", stderr=""):
+    return types.SimpleNamespace(returncode=returncode, stdout=stdout, stderr=stderr)
+
+
+# ---------------------------------------------------------------------------
+# _find_existing_pr
+# ---------------------------------------------------------------------------
+
+
+def test_find_existing_pr_returns_url_when_pr_exists(monkeypatch):
+    url = "https://github.com/owner/repo/pull/25"
+    monkeypatch.setattr(
+        pub_mod,
+        "run_command",
+        lambda cmd, cwd=None, logger=None: _make_result(stdout=url + "\n"),
+    )
+
+    assert _find_existing_pr(REPO, BRANCH, REPO_ROOT) == url
+
+
+def test_find_existing_pr_returns_none_when_no_pr(monkeypatch):
+    monkeypatch.setattr(
+        pub_mod,
+        "run_command",
+        lambda cmd, cwd=None, logger=None: _make_result(returncode=1, stderr="no pull requests"),
+    )
+
+    assert _find_existing_pr(REPO, BRANCH, REPO_ROOT) is None
+
+
+def test_find_existing_pr_returns_none_on_empty_stdout(monkeypatch):
+    monkeypatch.setattr(
+        pub_mod,
+        "run_command",
+        lambda cmd, cwd=None, logger=None: _make_result(stdout=""),
+    )
+
+    assert _find_existing_pr(REPO, BRANCH, REPO_ROOT) is None
+
+
+# ---------------------------------------------------------------------------
+# _create_pr — reuses existing PR
+# ---------------------------------------------------------------------------
+
+
+def test_create_pr_returns_existing_pr_url(monkeypatch):
+    """When a PR already exists, _create_pr should return its URL without creating a new one."""
+    existing_url = "https://github.com/owner/repo/pull/25"
+    commands_run = []
+
+    def fake_run_command(cmd, cwd=None, logger=None):
+        commands_run.append(cmd)
+        # First call is _find_existing_pr (gh pr view)
+        if "view" in cmd:
+            return _make_result(stdout=existing_url + "\n")
+        # Should never reach gh pr create
+        return _make_result(returncode=1, stderr="should not be called")
+
+    monkeypatch.setattr(pub_mod, "run_command", fake_run_command)
+
+    result = _create_pr(REPO, BRANCH, ISSUE, REPO_ROOT)
+    assert result == existing_url
+    # Verify gh pr create was never called
+    assert not any("create" in cmd for cmd in commands_run)
+
+
+def test_create_pr_creates_new_when_none_exists(monkeypatch):
+    """When no PR exists, _create_pr should create one."""
+    new_url = "https://github.com/owner/repo/pull/30"
+
+    def fake_run_command(cmd, cwd=None, logger=None):
+        if "view" in cmd:
+            return _make_result(returncode=1, stderr="no pull requests found")
+        if "create" in cmd:
+            return _make_result(stdout=new_url + "\n")
+        return _make_result()
+
+    monkeypatch.setattr(pub_mod, "run_command", fake_run_command)
+
+    result = _create_pr(REPO, BRANCH, ISSUE, REPO_ROOT)
+    assert result == new_url
+
+
+# ---------------------------------------------------------------------------
+# publish — end-to-end with existing PR
+# ---------------------------------------------------------------------------
+
+
+def test_publish_with_existing_pr_url_skips_creation(monkeypatch):
+    """When pr_url is passed, publish pushes but skips PR creation entirely."""
+    calls = []
+
+    def fake_run_command(cmd, cwd=None, logger=None):
+        calls.append(cmd)
+        if "status" in cmd:
+            return _make_result(stdout="M file.py\n")
+        if "add" in cmd or "commit" in cmd:
+            return _make_result()
+        if "log" in cmd:
+            return _make_result(stdout="abc123 some commit\n")
+        if "push" in cmd:
+            return _make_result()
+        return _make_result()
+
+    monkeypatch.setattr(pub_mod, "run_command", fake_run_command)
+
+    result = publish(REPO, BRANCH, ISSUE, REPO_ROOT, pr_url="https://github.com/owner/repo/pull/25")
+    assert result == "https://github.com/owner/repo/pull/25"
+    # gh pr create / gh pr view should never be called
+    assert not any("pr" in str(cmd) for cmd in calls)
+
+
+def test_publish_without_pr_url_detects_existing(monkeypatch):
+    """When no pr_url is passed but a PR exists, publish detects and returns it."""
+    existing_url = "https://github.com/owner/repo/pull/25"
+
+    def fake_run_command(cmd, cwd=None, logger=None):
+        if "status" in cmd:
+            return _make_result(stdout="M file.py\n")
+        if "add" in cmd or "commit" in cmd:
+            return _make_result()
+        if "log" in cmd:
+            return _make_result(stdout="abc123 some commit\n")
+        if "push" in cmd:
+            return _make_result()
+        if "view" in cmd:
+            return _make_result(stdout=existing_url + "\n")
+        return _make_result()
+
+    monkeypatch.setattr(pub_mod, "run_command", fake_run_command)
+
+    result = publish(REPO, BRANCH, ISSUE, REPO_ROOT)
+    assert result == existing_url


### PR DESCRIPTION
The publish stage now checks for an existing open PR via `gh pr view`
before attempting `gh pr create`, preventing pipeline failures on re-runs.

https://claude.ai/code/session_01EG6by14gvsETThvcWWCkmw