### PR TITLE
Enhance PR body with issue context, diff stats, and labels

### DIFF
--- a/aiorchestra/pipeline.py
+++ b/aiorchestra/pipeline.py
@@ -340,7 +340,9 @@ class Pipeline:
         ai_cfg = config.get("ai", {})
         review_cfg = config.get("review", {})
         ci_cfg = config.get("ci", {})
-        enabled_tiers = [t.get("name", "?") for t in review_cfg.get("tiers", []) if t.get("enabled", False)]
+        enabled_tiers = [
+            t.get("name", "?") for t in review_cfg.get("tiers", []) if t.get("enabled", False)
+        ]
         log.info(
             "Config: provider=%s model=%s review=%s ci_timeout=%ss",
             ai_cfg.get("provider", "claude-code"),

--- a/aiorchestra/stages/publish.py
+++ b/aiorchestra/stages/publish.py
@@ -102,6 +102,41 @@ def _find_existing_pr(repo: str, branch: str, repo_root: str) -> str | None:
     return None
 
 
+def _build_pr_body(issue: IssueData, repo_root: str) -> str:
+    """Build a descriptive PR body from the issue metadata and diff stats."""
+    number = issue["number"]
+    sections: list[str] = []
+
+    # Summary
+    sections.append(f"Automated implementation for #{number}.")
+
+    # Issue context — reproduce the original description so reviewers don't
+    # have to click through.
+    issue_body = issue.get("body", "").strip()
+    if issue_body:
+        sections.append(f"## Issue description\n\n{issue_body}")
+
+    # Changed files summary via git diff --stat (zero AI cost).
+    diff_stat = run_command(
+        ["git", "diff", "--stat", "origin/main...HEAD"],
+        cwd=repo_root,
+        logger=log,
+    )
+    if diff_stat.returncode == 0 and diff_stat.stdout.strip():
+        sections.append(f"## Changes\n\n```\n{diff_stat.stdout.strip()}\n```")
+
+    # Labels carried over from the issue.
+    labels = issue.get("labels", [])
+    if labels:
+        badge_list = ", ".join(f"`{lbl}`" for lbl in labels)
+        sections.append(f"**Labels:** {badge_list}")
+
+    # Closing reference must come last so GitHub links the PR to the issue.
+    sections.append(f"Closes #{number}")
+
+    return "\n\n".join(sections)
+
+
 def _create_pr(repo: str, branch: str, issue: IssueData, repo_root: str) -> PublishResult:
     """Create a PR for the pushed branch, or return the existing one."""
     existing = _find_existing_pr(repo, branch, repo_root)
@@ -110,7 +145,7 @@ def _create_pr(repo: str, branch: str, issue: IssueData, repo_root: str) -> Publ
         return existing
 
     title = f"Fix #{issue['number']}: {issue['title']}"
-    body = f"Automated implementation for #{issue['number']}.\n\nCloses #{issue['number']}"
+    body = _build_pr_body(issue, repo_root)
 
     log.info("Checking for existing PR for branch %s", branch)
     existing = run_command(

--- a/tests/test_publish.py
+++ b/tests/test_publish.py
@@ -3,9 +3,15 @@
 import types
 
 from aiorchestra.stages import publish as pub_mod
-from aiorchestra.stages.publish import _create_pr, _find_existing_pr, publish
+from aiorchestra.stages.publish import _build_pr_body, _create_pr, _find_existing_pr, publish
 
 ISSUE = {"number": 24, "title": "Add multi-level verbose logging"}
+ISSUE_RICH = {
+    "number": 24,
+    "title": "Add multi-level verbose logging",
+    "body": "We need verbose, debug, and trace levels.",
+    "labels": ["enhancement", "logging"],
+}
 REPO = "owner/repo"
 BRANCH = "claude/24"
 REPO_ROOT = "/tmp/fake-repo"
@@ -86,12 +92,54 @@ def test_create_pr_creates_new_when_none_exists(monkeypatch):
             return _make_result(returncode=1, stderr="no pull requests found")
         if "create" in cmd:
             return _make_result(stdout=new_url + "\n")
+        # git diff --stat for PR body builder
+        if "diff" in cmd:
+            return _make_result(stdout=" file.py | 2 +-\n 1 file changed\n")
         return _make_result()
 
     monkeypatch.setattr(pub_mod, "run_command", fake_run_command)
 
     result = _create_pr(REPO, BRANCH, ISSUE, REPO_ROOT)
     assert result == new_url
+
+
+# ---------------------------------------------------------------------------
+# _build_pr_body
+# ---------------------------------------------------------------------------
+
+
+def test_build_pr_body_minimal(monkeypatch):
+    """A minimal issue (no body/labels) still produces a valid PR body."""
+    monkeypatch.setattr(
+        pub_mod,
+        "run_command",
+        lambda cmd, cwd=None, logger=None: _make_result(stdout=""),
+    )
+    body = _build_pr_body(ISSUE, REPO_ROOT)
+    assert "Automated implementation for #24" in body
+    assert "Closes #24" in body
+    # No issue-description or labels sections
+    assert "## Issue description" not in body
+    assert "**Labels:**" not in body
+
+
+def test_build_pr_body_rich(monkeypatch):
+    """A rich issue includes description, diff stats, and labels."""
+    diff_stat = " src/log.py | 10 +++++++---\n 1 file changed, 7 insertions(+), 3 deletions(-)"
+
+    monkeypatch.setattr(
+        pub_mod,
+        "run_command",
+        lambda cmd, cwd=None, logger=None: _make_result(stdout=diff_stat),
+    )
+    body = _build_pr_body(ISSUE_RICH, REPO_ROOT)
+    assert "## Issue description" in body
+    assert "verbose, debug, and trace levels" in body
+    assert "## Changes" in body
+    assert "src/log.py" in body
+    assert "`enhancement`" in body
+    assert "`logging`" in body
+    assert "Closes #24" in body
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
Refactored PR body generation to include richer context from the original issue, making pull requests more informative for reviewers without requiring them to navigate to the issue tracker.

## Key Changes
- **New `_build_pr_body()` function**: Extracts PR body generation logic into a dedicated, testable function that constructs a multi-section body including:
  - Automated implementation summary
  - Original issue description (if present)
  - Git diff statistics showing changed files
  - Issue labels formatted as badges
  - GitHub closing reference
  
- **Enhanced PR creation**: Updated `_create_pr()` to use the new `_build_pr_body()` function instead of a hardcoded minimal body

- **Comprehensive test coverage**: Added two test cases:
  - `test_build_pr_body_minimal`: Validates that minimal issues (without body/labels) still produce valid PR bodies
  - `test_build_pr_body_rich`: Verifies that rich issues with descriptions, labels, and diff stats are properly formatted

## Implementation Details
- The function gracefully handles missing optional fields (issue body, labels) by omitting those sections
- Diff statistics are retrieved via `git diff --stat origin/main...HEAD` with error handling for command failures
- Labels are formatted as inline code badges for better visibility in GitHub
- The closing reference (`Closes #<number>`) is placed last to ensure GitHub properly links the PR to the issue
- Test fixtures include both minimal and rich issue examples to cover different scenarios

https://claude.ai/code/session_01GuUA1LLbfVDKVjKfP4BoAb