### PR TITLE
Update AI model configurations and enable additional review tiers

### DIFF
--- a/README.md
+++ b/README.md
@@ -159,7 +159,7 @@ label: "claude"
 
 ai:
   provider: "claude-code"   # "claude-code" (CLI) or "claude-api"
-  model: "sonnet"
+  model: "claude-opus-4-6"
   max_retries: 3
   skip_permissions: true    # use --dangerously-skip-permissions (default: true)
   # allowed_tools:          # optional — restrict agent's tool access

--- a/aiorchestra.yaml.example
+++ b/aiorchestra.yaml.example
@@ -5,7 +5,7 @@ label: "claude"
 
 ai:
   provider: "claude-code"   # "claude-code", "codex", "gemini", "opencode", "jules", "ollama"
-  model: "sonnet"           # model hint forwarded to the provider's --model flag
+  model: "claude-opus-4-6"  # model hint forwarded to the provider's --model flag
   max_retries: 3
 
 # OpenCode provider example:

--- a/aiorchestra/config.py
+++ b/aiorchestra/config.py
@@ -14,7 +14,7 @@ DEFAULTS = {
     "label": "claude",
     "ai": {
         "provider": "claude-code",
-        "model": "sonnet",
+        "model": "claude-opus-4-6",
         "max_retries": 3,
         "skip_permissions": True,
     },
@@ -27,7 +27,7 @@ DEFAULTS = {
         "tiers": [
             {
                 "name": "static-analysis",
-                "enabled": False,
+                "enabled": True,
                 "commands": [
                     "semgrep --config=auto --quiet .",
                     "bandit -r . -q",
@@ -37,6 +37,7 @@ DEFAULTS = {
                 "name": "ai-review",
                 "enabled": True,
                 "provider": "claude-code",
+                "model": "claude-sonnet-4-6",
             },
             {
                 "name": "cross-model-review",
@@ -51,9 +52,9 @@ DEFAULTS = {
             },
             {
                 "name": "cross-agent-review",
-                "enabled": False,
+                "enabled": True,
                 "provider": "auto",
-                "strict": True,
+                "strict": False,
             },
             {
                 "name": "human-required",

--- a/aiorchestra/pipeline.py
+++ b/aiorchestra/pipeline.py
@@ -340,7 +340,9 @@ class Pipeline:
         ai_cfg = config.get("ai", {})
         review_cfg = config.get("review", {})
         ci_cfg = config.get("ci", {})
-        enabled_tiers = [t.get("name", "?") for t in review_cfg.get("tiers", []) if t.get("enabled", False)]
+        enabled_tiers = [
+            t.get("name", "?") for t in review_cfg.get("tiers", []) if t.get("enabled", False)
+        ]
         log.info(
             "Config: provider=%s model=%s review=%s ci_timeout=%ss",
             ai_cfg.get("provider", "claude-code"),

--- a/tests/test_logging.py
+++ b/tests/test_logging.py
@@ -409,12 +409,12 @@ def test_cli_provider_logs_model(monkeypatch, caplog):
 
     monkeypatch.setattr(subprocess, "run", fake_run)
 
-    provider = ClaudeCodeProvider({"model": "sonnet", "skip_permissions": True})
+    provider = ClaudeCodeProvider({"model": "claude-opus-4-6", "skip_permissions": True})
     with caplog.at_level(logging.INFO, logger="aiorchestra.ai._cli"):
         provider.run("test prompt")
 
     info_msgs = [r.message for r in caplog.records if r.levelname == "INFO"]
-    assert any("sonnet" in m for m in info_msgs)
+    assert any("claude-opus-4-6" in m for m in info_msgs)
 
 
 def test_cli_provider_logs_default_when_no_model(monkeypatch, caplog):


### PR DESCRIPTION
## Summary
This PR updates the default AI model configurations across the codebase and enables additional code review tiers in the orchestration pipeline.

## Key Changes
- **Model Updates**: Changed default model from `sonnet` to `claude-opus-4-6` in:
  - Main configuration (`aiorchestra/config.py`)
  - Example configuration files (`README.md`, `aiorchestra.yaml.example`)
  - Test fixtures (`tests/test_logging.py`)

- **Review Tier Enablement**:
  - Enabled `static-analysis` tier (was disabled)
  - Enabled `cross-agent-review` tier (was disabled)
  - Added explicit model specification `claude-sonnet-4-6` to `ai-review` tier

- **Cross-Agent Review Configuration**: Changed `strict` mode from `True` to `False` in the cross-agent-review tier

## Implementation Details
- The model name change from `sonnet` to `claude-opus-4-6` is applied consistently across configuration files and test assertions
- Static analysis tools (semgrep, bandit) are now part of the default review pipeline
- Cross-agent review is now enabled with relaxed strictness settings, allowing for more flexible multi-agent collaboration
- The ai-review tier now explicitly specifies its model preference to ensure consistent behavior

https://claude.ai/code/session_01DxjxUtp7PkGgpKm1NPpVis