### PR TITLE
Fix #38: Re-run CI after review-fix pushes to catch regressions

### DIFF
--- a/aiorchestra/pipeline.py
+++ b/aiorchestra/pipeline.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 from dataclasses import dataclass
 
 import logging
+import typing
 import os
 import time
 
@@ -426,6 +427,14 @@ class Pipeline:
         if not ctx.config.get("review", {}).get("enabled", True):
             return pr_url
 
+        ci_enabled = ctx.config.get("ci", {}).get("enabled", True)
+
+        def post_publish_ci_gate(current_pr_url: str) -> str | None:
+            if not ci_enabled:
+                return current_pr_url
+            log.info("[review] Running post-publish CI verification")
+            return self._run_ci_fix_loop(ctx, current_pr_url)
+
         return self._run_remote_fix_loop(
             ctx,
             pr_url,
@@ -438,6 +447,7 @@ class Pipeline:
                 issue=ctx.issue,
                 repo_root=ctx.repo_root,
             ),
+            post_publish_fn=post_publish_ci_gate,
         )
 
     def _run_remote_fix_loop(
@@ -447,6 +457,7 @@ class Pipeline:
         stage_name: str,
         prompt_name: str,
         check_fn: RemoteCheckFn,
+        post_publish_fn: typing.Callable[[str], str | None] | None = None,
     ) -> str | None:
         for attempt in range(1, ctx.max_retries + 1):
             ok, feedback = check_fn(pr_url)
@@ -474,6 +485,11 @@ class Pipeline:
             )
             if not pr_url:
                 return None
+
+            if post_publish_fn is not None:
+                pr_url = post_publish_fn(pr_url)
+                if not pr_url:
+                    return None
 
         log.error("%s failed after %d attempts", stage_name, ctx.max_retries)
         return None

--- a/tests/test_pipeline.py
+++ b/tests/test_pipeline.py
@@ -589,6 +589,155 @@ def test_implement_mode_used_when_branch_has_no_existing_work(monkeypatch, tmp_p
     assert calls == [("implement", "implement")]
 
 
+def test_review_fix_triggers_ci_recheck(monkeypatch, tmp_path):
+    """After a review-fix publish, CI must be re-checked and failures remediated."""
+    calls: list[tuple] = []
+    # Initial validation passes, then review-fix validation passes,
+    # then CI-fix validation passes.
+    validate_results = iter([(True, None), (True, None), (True, None)])
+    # First CI check (after initial publish) passes.
+    # Second CI check (after review-fix publish) fails, then passes after fix.
+    ci_results = iter([(True, None), (False, "lint error"), (True, None)])
+    # Review fails once, then passes.
+    review_results = iter([(False, "needs refactor"), (True, None)])
+
+    monkeypatch.setattr(
+        "aiorchestra.pipeline.prepare_environment",
+        lambda repo, branch, workspace: str(tmp_path),
+    )
+    monkeypatch.setattr(
+        "aiorchestra.pipeline.load_config",
+        lambda path, repo_root=None: {
+            "ai": {"max_retries": 3},
+            "ci": {"enabled": True},
+            "review": {"enabled": True},
+        },
+    )
+    monkeypatch.setattr("aiorchestra.pipeline._has_changes", lambda repo_root: True)
+    monkeypatch.setattr("aiorchestra.pipeline.enrich_issue", lambda issue, config: "")
+
+    def fake_implement(
+        issue,
+        config,
+        prompt_name="implement",
+        error_text=None,
+        repo_root=None,
+        osint_context="",
+        repo=None,
+    ):
+        calls.append(("implement", prompt_name, error_text))
+        return InvokeResult(success=True)
+
+    def fake_validate(config, repo_root=None):
+        calls.append(("validate",))
+        return next(validate_results)
+
+    def fake_publish(repo, branch, issue, repo_root, pr_url=None):
+        calls.append(("publish",))
+        return pr_url or "https://example.test/pr/1"
+
+    def fake_wait_for_ci(pr_url, config):
+        calls.append(("wait_for_ci",))
+        return next(ci_results)
+
+    def fake_review(repo, branch, config, issue=None, repo_root=None):
+        calls.append(("review",))
+        return next(review_results)
+
+    monkeypatch.setattr("aiorchestra.pipeline.implement", fake_implement)
+    monkeypatch.setattr("aiorchestra.pipeline.validate", fake_validate)
+    monkeypatch.setattr("aiorchestra.pipeline.publish", fake_publish)
+    monkeypatch.setattr("aiorchestra.pipeline.wait_for_ci", fake_wait_for_ci)
+    monkeypatch.setattr("aiorchestra.pipeline.review", fake_review)
+
+    pipeline = Pipeline(
+        repo="owner/repo",
+        label="claude",
+        config={"ai": {"provider": "claude-code"}},
+    )
+
+    assert pipeline._process_issue({"number": 38, "title": "Review CI recheck"}) is True
+
+    assert calls == [
+        # Initial implementation + validation + publish
+        ("implement", "implement", None),
+        ("validate",),
+        ("publish",),
+        # Initial CI check passes
+        ("wait_for_ci",),
+        # Review fails → fix → validate → publish
+        ("review",),
+        ("implement", "fix_review", "needs refactor"),
+        ("validate",),
+        ("publish",),
+        # Post-publish CI gate: CI fails → fix → validate → publish → CI passes
+        ("wait_for_ci",),
+        ("implement", "fix_ci", "lint error"),
+        ("validate",),
+        ("publish",),
+        ("wait_for_ci",),
+        # Review passes
+        ("review",),
+    ]
+
+
+def test_review_fix_ci_failure_fails_issue(monkeypatch, tmp_path):
+    """If CI fails after review-fix and cannot be remediated, the issue fails."""
+    validate_results = iter([(True, None), (True, None), (True, None), (True, None), (True, None)])
+    # Initial CI passes, post-review-fix CI always fails.
+    ci_results = iter(
+        [(True, None), (False, "ci broke"), (False, "ci broke"), (False, "ci broke")]
+    )
+    review_results = iter([(False, "fix needed")])
+
+    monkeypatch.setattr(
+        "aiorchestra.pipeline.prepare_environment",
+        lambda repo, branch, workspace: str(tmp_path),
+    )
+    monkeypatch.setattr(
+        "aiorchestra.pipeline.load_config",
+        lambda path, repo_root=None: {
+            "ai": {"max_retries": 3},
+            "ci": {"enabled": True},
+            "review": {"enabled": True},
+        },
+    )
+    monkeypatch.setattr("aiorchestra.pipeline._has_changes", lambda repo_root: True)
+    monkeypatch.setattr("aiorchestra.pipeline.enrich_issue", lambda issue, config: "")
+    monkeypatch.setattr(
+        "aiorchestra.pipeline.implement",
+        lambda issue, config, prompt_name="implement", error_text=None, repo_root=None, osint_context="", repo=None: InvokeResult(
+            success=True
+        ),
+    )
+    monkeypatch.setattr(
+        "aiorchestra.pipeline.validate",
+        lambda config, repo_root=None: next(validate_results),
+    )
+    monkeypatch.setattr(
+        "aiorchestra.pipeline.publish",
+        lambda repo, branch, issue, repo_root, pr_url=None: pr_url
+        or "https://example.test/pr/1",
+    )
+    monkeypatch.setattr(
+        "aiorchestra.pipeline.wait_for_ci",
+        lambda pr_url, config: next(ci_results),
+    )
+    monkeypatch.setattr(
+        "aiorchestra.pipeline.review",
+        lambda repo, branch, config, issue=None, repo_root=None: next(review_results),
+    )
+
+    pipeline = Pipeline(
+        repo="owner/repo",
+        label="claude",
+        config={"ai": {"provider": "claude-code"}},
+    )
+
+    # Should fail because CI can't be fixed after the review-fix publish
+    assert pipeline._process_issue({"number": 39, "title": "CI unfixable"}) is False
+
+
 def test_prepare_fails_on_low_disk_space(monkeypatch, tmp_path):
     """Preparation must refuse to proceed when disk space is too low."""
     from aiorchestra.stages import prepare as prep_mod

--- a/tests/test_pipeline.py
+++ b/tests/test_pipeline.py
@@ -685,9 +685,7 @@ def test_review_fix_ci_failure_fails_issue(monkeypatch, tmp_path):
     """If CI fails after review-fix and cannot be remediated, the issue fails."""
     validate_results = iter([(True, None), (True, None), (True, None), (True, None), (True, None)])
     # Initial CI passes, post-review-fix CI always fails.
-    ci_results = iter(
-        [(True, None), (False, "ci broke"), (False, "ci broke"), (False, "ci broke")]
-    )
+    ci_results = iter([(True, None), (False, "ci broke"), (False, "ci broke"), (False, "ci broke")])
     review_results = iter([(False, "fix needed")])
 
     monkeypatch.setattr(
@@ -706,8 +704,8 @@ def test_review_fix_ci_failure_fails_issue(monkeypatch, tmp_path):
     monkeypatch.setattr("aiorchestra.pipeline.enrich_issue", lambda issue, config: "")
     monkeypatch.setattr(
         "aiorchestra.pipeline.implement",
-        lambda issue, config, prompt_name="implement", error_text=None, repo_root=None, osint_context="", repo=None: InvokeResult(
-            success=True
+        lambda issue, config, prompt_name="implement", error_text=None, repo_root=None, osint_context="", repo=None: (
+            InvokeResult(success=True)
         ),
     )
     monkeypatch.setattr(
@@ -716,8 +714,7 @@ def test_review_fix_ci_failure_fails_issue(monkeypatch, tmp_path):
     )
     monkeypatch.setattr(
         "aiorchestra.pipeline.publish",
-        lambda repo, branch, issue, repo_root, pr_url=None: pr_url
-        or "https://example.test/pr/1",
+        lambda repo, branch, issue, repo_root, pr_url=None: pr_url or "https://example.test/pr/1",
     )
     monkeypatch.setattr(
         "aiorchestra.pipeline.wait_for_ci",


### PR DESCRIPTION
Automated implementation for #38.

## Issue description

## Problem

After review-fix commits are pushed, the pipeline does not wait for CI to complete or verify it passes. This means review fixes can introduce CI failures that go undetected.

### Observed in Issue #32 (PR #33)

The pipeline flow was:

1. **Implement** → validate (pass) → publish → **CI check** (fail → fix → pass) ✅
2. **Review fix 1** → validate (pass) → publish → **no CI check** ❌
3. **Review fix 2** → validate (pass) → publish → **no CI check** ❌

The final commit on PR #33 has **2 lint failures** that were never caught because the pipeline only checks CI after the initial publish — not after review-fix pushes.

Local validation (`ruff check .`) passed each time, but CI lint failed — likely due to config or version differences. Because CI was never re-checked after review fixes, this slipped through to the final PR.

### Current pipeline structure

```
_process_issue:
    prepare → _run_validation_loop → publish → _run_ci_fix_loop → _run_review_fix_loop → done
```

`_run_review_fix_loop` calls `publish()` internally but never calls `wait_for_ci()` afterward.

## Proposed Fix

After each review-fix publish, cycle back through CI verification before continuing. The simplest approach:

**Option A — Re-run CI after review fixes:**

In `_run_review_fix_loop`, after a successful publish of review-fix changes, call `wait_for_ci()` and handle failures (either feed them back into the fix loop or fail the issue).

```
_run_review_fix_loop:
    for each review attempt:
        review → if failed → implement fix → validate → publish → wait_for_ci → loop
```

**Option B — Unified post-push CI gate:**

Extract the CI wait into a shared step that runs after every `publish()` call, regardless of whether it's the initial publish or a review-fix publish. This would also cover CI-fix pushes that might introduce new failures.

## Acceptance Criteria

- [ ] CI is checked after every push (initial, CI-fix, and review-fix)
- [ ] CI failures after review-fix pushes trigger remediation or fail the issue
- [ ] No infinite loops — CI-fix attempts within the review loop respect `max_retries`
- [ ] Pipeline logs clearly indicate which phase triggered the CI re-check
- [ ] Tests cover the review-fix → CI-fail → remediation path

## Changes

```
aiorchestra/pipeline.py |  16 ++++++
 tests/test_pipeline.py  | 149 ++++++++++++++++++++++++++++++++++++++++++++++++
 2 files changed, 165 insertions(+)
```

**Labels:** `claude`, `aiorchestra`

Closes #38