### PR TITLE
Add review-only mode to skip implementation and publishing

### DIFF
--- a/aiorchestra/cli.py
+++ b/aiorchestra/cli.py
@@ -66,6 +66,11 @@ def build_parser() -> argparse.ArgumentParser:
     )
     run.add_argument("--dry-run", action="store_true", help="Show plan without executing")
     run.add_argument(
+        "--review-only",
+        action="store_true",
+        help="Skip implementation — only validate and review existing work on the branch",
+    )
+    run.add_argument(
         "--verbose",
         "-v",
         action="count",
@@ -162,6 +167,7 @@ def main(argv: list[str] | None = None) -> int:
             config_path=args.config,
             dry_run=args.dry_run,
             workspace=args.workspace,
+            review_only=args.review_only,
         )
         if args.watch:
             return _watch_loop(pipeline.run, _resolve_poll_interval(args, config))

--- a/aiorchestra/pipeline.py
+++ b/aiorchestra/pipeline.py
@@ -92,6 +92,7 @@ class Pipeline:
         dry_run: bool = False,
         workspace: str | None = None,
         parallel: bool = True,
+        review_only: bool = False,
     ):
         self.repo = repo
         self.label = label
@@ -101,6 +102,7 @@ class Pipeline:
         self.dry_run = dry_run
         self.workspace = workspace
         self.parallel = parallel
+        self.review_only = review_only
 
     # ------------------------------------------------------------------
     # Public entry point
@@ -267,6 +269,9 @@ class Pipeline:
     def _process_issue(self, issue: IssueData) -> bool | str:
         """Process a single issue. Returns True on success, False on failure,
         or ``_DEFERRED`` when the issue needs human clarification."""
+        if self.review_only:
+            return self._process_issue_review_only(issue)
+
         issue_start = time.monotonic()
 
         t0 = time.monotonic()
@@ -327,6 +332,65 @@ class Pipeline:
         )
         log.info("Issue #%d completed successfully.", issue["number"])
         return True
+
+    def _process_issue_review_only(self, issue: IssueData) -> bool:
+        """Review-only mode: validate and review existing work without implementing.
+
+        Skips implementation, publishing, and CI — just runs validation and
+        the review tiers on whatever code is already on the branch.
+        """
+        issue_start = time.monotonic()
+        log.info("Review-only mode for issue #%d", issue["number"])
+
+        t0 = time.monotonic()
+        ctx = self._prepare_issue(issue)
+        prepare_elapsed = time.monotonic() - t0
+        log.info("[prepare] completed in %s", _fmt_duration(prepare_elapsed))
+        if ctx is None:
+            return False
+
+        if not _branch_has_existing_work(ctx.repo_root):
+            log.error("Review-only mode requires existing work on the branch")
+            return False
+
+        passed = True
+
+        # Run validation (tests, lint, static analysis).
+        t0 = time.monotonic()
+        val_ok, val_feedback = validate(ctx.config, repo_root=ctx.repo_root)
+        validate_elapsed = time.monotonic() - t0
+        log.info("[validate] completed in %s", _fmt_duration(validate_elapsed))
+        if not val_ok:
+            log.warning("Validation failed: %.500s", val_feedback)
+            passed = False
+
+        # Run review tiers.
+        t0 = time.monotonic()
+        rev_ok, rev_feedback = review(
+            ctx.repo,
+            ctx.branch,
+            ctx.config,
+            issue=ctx.issue,
+            repo_root=ctx.repo_root,
+        )
+        review_elapsed = time.monotonic() - t0
+        log.info("[review] completed in %s", _fmt_duration(review_elapsed))
+        if not rev_ok:
+            log.warning("Review failed: %.500s", rev_feedback)
+            passed = False
+
+        total_elapsed = time.monotonic() - issue_start
+        status = "PASSED" if passed else "FAILED"
+        log.info(
+            "Review-only #%d %s — total: %s (prepare: %s, validate: %s, review: %s)",
+            issue["number"],
+            status,
+            _fmt_duration(total_elapsed),
+            _fmt_duration(prepare_elapsed),
+            _fmt_duration(validate_elapsed),
+            _fmt_duration(review_elapsed),
+        )
+        return passed
 
     def _prepare_issue(self, issue: IssueData) -> _IssueContext | None:
         branch = build_agent_branch(self.config, issue["number"])

--- a/tests/test_pipeline.py
+++ b/tests/test_pipeline.py
@@ -735,6 +735,141 @@ def test_review_fix_ci_failure_fails_issue(monkeypatch, tmp_path):
     assert pipeline._process_issue({"number": 39, "title": "CI unfixable"}) is False
 
 
+# ---------------------------------------------------------------------------
+# Review-only mode tests
+# ---------------------------------------------------------------------------
+
+
+def test_review_only_skips_implement_and_publish(monkeypatch, tmp_path):
+    """Review-only mode runs validate + review but never calls implement or publish."""
+    calls: list[str] = []
+
+    monkeypatch.setattr(
+        "aiorchestra.pipeline.prepare_environment",
+        lambda repo, branch, workspace: str(tmp_path),
+    )
+    monkeypatch.setattr(
+        "aiorchestra.pipeline.load_config",
+        lambda path, repo_root=None: {
+            "ai": {"max_retries": 1},
+            "ci": {"enabled": True},
+            "review": {"enabled": True},
+        },
+    )
+    monkeypatch.setattr("aiorchestra.pipeline._branch_has_existing_work", lambda repo_root: True)
+    monkeypatch.setattr("aiorchestra.pipeline.enrich_issue", lambda issue, config: "")
+
+    def fake_implement(
+        issue,
+        config,
+        prompt_name="implement",
+        error_text=None,
+        repo_root=None,
+        osint_context="",
+        repo=None,
+    ):
+        calls.append("implement")
+        return InvokeResult(success=True)
+
+    def fake_validate(config, repo_root=None):
+        calls.append("validate")
+        return True, None
+
+    def fake_review(repo, branch, config, issue=None, repo_root=None):
+        calls.append("review")
+        return True, None
+
+    def fake_publish(repo, branch, issue, repo_root, pr_url=None):
+        calls.append("publish")
+        return "https://example.test/pr/1"
+
+    monkeypatch.setattr("aiorchestra.pipeline.implement", fake_implement)
+    monkeypatch.setattr("aiorchestra.pipeline.validate", fake_validate)
+    monkeypatch.setattr("aiorchestra.pipeline.review", fake_review)
+    monkeypatch.setattr("aiorchestra.pipeline.publish", fake_publish)
+
+    pipeline = Pipeline(
+        repo="owner/repo",
+        label="claude",
+        config={"ai": {"provider": "claude-code"}},
+        review_only=True,
+    )
+
+    assert pipeline._process_issue({"number": 30, "title": "Review my code"}) is True
+    assert calls == ["validate", "review"]
+
+
+def test_review_only_fails_when_no_existing_work(monkeypatch, tmp_path):
+    """Review-only mode should fail if the branch has no commits ahead of main."""
+    monkeypatch.setattr(
+        "aiorchestra.pipeline.prepare_environment",
+        lambda repo, branch, workspace: str(tmp_path),
+    )
+    monkeypatch.setattr(
+        "aiorchestra.pipeline.load_config",
+        lambda path, repo_root=None: {
+            "ai": {"max_retries": 1},
+            "ci": {"enabled": False},
+            "review": {"enabled": True},
+        },
+    )
+    monkeypatch.setattr("aiorchestra.pipeline._branch_has_existing_work", lambda repo_root: False)
+    monkeypatch.setattr("aiorchestra.pipeline.enrich_issue", lambda issue, config: "")
+
+    pipeline = Pipeline(
+        repo="owner/repo",
+        label="claude",
+        config={"ai": {"provider": "claude-code"}},
+        review_only=True,
+    )
+
+    assert pipeline._process_issue({"number": 31, "title": "Empty branch"}) is False
+
+
+def test_review_only_reports_validation_failure(monkeypatch, tmp_path):
+    """Review-only mode should still run review even if validation fails,
+    and return False overall."""
+    calls: list[str] = []
+
+    monkeypatch.setattr(
+        "aiorchestra.pipeline.prepare_environment",
+        lambda repo, branch, workspace: str(tmp_path),
+    )
+    monkeypatch.setattr(
+        "aiorchestra.pipeline.load_config",
+        lambda path, repo_root=None: {
+            "ai": {"max_retries": 1},
+            "ci": {"enabled": False},
+            "review": {"enabled": True},
+        },
+    )
+    monkeypatch.setattr("aiorchestra.pipeline._branch_has_existing_work", lambda repo_root: True)
+    monkeypatch.setattr("aiorchestra.pipeline.enrich_issue", lambda issue, config: "")
+
+    def fake_validate(config, repo_root=None):
+        calls.append("validate")
+        return False, "lint errors found"
+
+    def fake_review(repo, branch, config, issue=None, repo_root=None):
+        calls.append("review")
+        return True, None
+
+    monkeypatch.setattr("aiorchestra.pipeline.validate", fake_validate)
+    monkeypatch.setattr("aiorchestra.pipeline.review", fake_review)
+
+    pipeline = Pipeline(
+        repo="owner/repo",
+        label="claude",
+        config={"ai": {"provider": "claude-code"}},
+        review_only=True,
+    )
+
+    result = pipeline._process_issue({"number": 32, "title": "Lint fail"})
+    assert result is False
+    # Both stages ran despite validation failure
+    assert calls == ["validate", "review"]
+
+
 def test_prepare_fails_on_low_disk_space(monkeypatch, tmp_path):
     """Preparation must refuse to proceed when disk space is too low."""
     from aiorchestra.stages import prepare as prep_mod


### PR DESCRIPTION
## Summary
Adds a new `--review-only` mode to the pipeline that validates and reviews existing work on a branch without running implementation or publishing stages. This is useful for code review workflows where the implementation has already been done.

## Key Changes
- **Pipeline class**: Added `review_only` parameter to `__init__` and new `_process_issue_review_only()` method that runs only validation and review stages
- **Review-only workflow**: 
  - Requires existing work on the branch (checked via `_branch_has_existing_work()`)
  - Runs validation and review stages sequentially
  - Skips implement, publish, and CI stages entirely
  - Returns `False` if validation or review fails, but still runs both stages
- **CLI**: Added `--review-only` flag to the `run` command to enable this mode
- **Tests**: Added three comprehensive test cases:
  - `test_review_only_skips_implement_and_publish`: Verifies only validate and review are called
  - `test_review_only_fails_when_no_existing_work`: Ensures mode fails gracefully when branch has no commits
  - `test_review_only_reports_validation_failure`: Confirms review still runs even if validation fails

## Implementation Details
- The `_process_issue_review_only()` method follows the same logging and timing patterns as the standard flow
- Validation failures don't prevent the review stage from running, allowing comprehensive feedback
- The mode is mutually exclusive with implementation—it assumes code already exists on the branch

https://claude.ai/code/session_015LRpKNsiVMj55p1JDxQkwb