### PR TITLE
Add guardrails to prevent AI agents from taking shortcuts on bug fixes

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -36,6 +36,43 @@ jobs:
         continue-on-error: true
         run: pip install semgrep && semgrep scan --config auto --error aiorchestra/
 
+  config-guard:
+    if: github.event_name == 'pull_request'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      - name: Check for protected config changes
+        run: |
+          PROTECTED_PATTERNS=(
+            "pyproject.toml"
+            ".semgrep/"
+            ".github/workflows/"
+            ".ruff.toml"
+            "setup.cfg"
+          )
+          BASE="${{ github.event.pull_request.base.sha }}"
+          HEAD="${{ github.event.pull_request.head.sha }}"
+          CHANGED=$(git diff --name-only "$BASE" "$HEAD")
+          FLAGGED=""
+          for pattern in "${PROTECTED_PATTERNS[@]}"; do
+            MATCHES=$(echo "$CHANGED" | grep "^${pattern}" || true)
+            if [ -n "$MATCHES" ]; then
+              FLAGGED="${FLAGGED}${MATCHES}"$'\n'
+            fi
+          done
+          if [ -n "$FLAGGED" ]; then
+            echo "::warning::Protected config files were modified in this PR:"
+            echo "$FLAGGED"
+            echo ""
+            echo "If this PR is an automated bug fix, these changes likely"
+            echo "indicate a shortcut (e.g. weakening a linter rule instead"
+            echo "of fixing the code). Please review carefully."
+            # To make this a hard gate, uncomment the next line:
+            # exit 1
+          fi
+
   test:
     runs-on: ubuntu-latest
     steps:

--- a/.semgrep/aiorchestra.yaml
+++ b/.semgrep/aiorchestra.yaml
@@ -121,6 +121,68 @@ rules:
     languages: [python]
     severity: WARNING
 
+  # --- Tier 2b: Anti-shortcut Guards ---
+
+  - id: no-try-except-import
+    patterns:
+      - pattern: |
+          try:
+              import $MOD
+              ...
+          except ImportError:
+              ...
+    paths:
+      exclude:
+        - tests/*
+    message: >-
+      Do not wrap imports in try/except ImportError. If the module is
+      required, add it to pyproject.toml dependencies. If it is truly
+      optional, document why in a comment and use a TYPE_CHECKING guard
+      instead.
+    languages: [python]
+    severity: ERROR
+
+  - id: no-try-except-from-import
+    patterns:
+      - pattern: |
+          try:
+              from $MOD import $NAME
+              ...
+          except ImportError:
+              ...
+    paths:
+      exclude:
+        - tests/*
+    message: >-
+      Do not wrap imports in try/except ImportError. If the module is
+      required, add it to pyproject.toml dependencies.
+    languages: [python]
+    severity: ERROR
+
+  - id: no-noqa-blanket
+    pattern-regex: '#\s*noqa\s*$'
+    paths:
+      exclude:
+        - tests/*
+    message: >-
+      Blanket '# noqa' suppresses all warnings on a line. Fix the
+      violation instead, or use a specific code like '# noqa: E501'
+      with a justification comment if truly needed.
+    languages: [python]
+    severity: WARNING
+
+  - id: no-type-ignore-blanket
+    pattern-regex: '#\s*type:\s*ignore\s*$'
+    paths:
+      exclude:
+        - tests/*
+    message: >-
+      Blanket '# type: ignore' hides real type errors. Use a specific
+      error code like '# type: ignore[import-untyped]' or fix the
+      underlying issue.
+    languages: [python]
+    severity: WARNING
+
   # --- Tier 3: Maintainability ---
 
   - id: no-deep-merge-bypass

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -45,6 +45,29 @@ discover → implement → validate → review → publish stages.
 - Tests required for all stages and providers
 - No new runtime dependencies without an ADR in think_tank
 
+## Bug Fix Rules
+
+When a CI check, linter, or test fails, fix the code — never weaken the tool:
+
+1. **Never weaken or disable a linter/formatter rule to fix a violation.**
+   Fix the code to comply with the existing rule. Do not change line-length,
+   disable rules, add `noqa` comments, or alter tool configs.
+2. **Never wrap imports in try/except to hide missing dependencies.**
+   Add the dependency to `pyproject.toml` `[project.dependencies]` (or
+   `[project.optional-dependencies]`) and, if present, `requirements.txt`.
+3. **Never modify CI workflows, test thresholds, semgrep rules, or tool
+   configs to make a failing check pass** unless explicitly asked by a human.
+4. **Prefer the smallest, most targeted fix.** If a one-line change fixes it,
+   don't restructure surrounding code.
+5. **Diagnose before fixing.** When a check fails, first identify *what rule*
+   was violated and *why*, then choose a fix that addresses the root cause.
+   A fix is correct when it satisfies the rule's intent, not just when CI
+   turns green.
+6. **Protected files — changes require human approval:**
+   `pyproject.toml [tool.*]`, `.semgrep/`, `.github/workflows/`,
+   `.ruff.toml`, `setup.cfg`. If a fix seems to require changing these,
+   stop and ask.
+
 ## Quality
 
 Enforced by CI, not by this file:

--- a/aiorchestra/templates/fix_ci.md
+++ b/aiorchestra/templates/fix_ci.md
@@ -8,4 +8,29 @@ CI output:
 
 {errors}
 
-Fix the issues causing CI to fail. Do NOT run tests — just fix the code.
+## Instructions
+
+Follow these steps IN ORDER:
+
+### Step 1 — Diagnose
+Read the CI output carefully. For each failure, identify:
+- Which CI job failed (lint, test, security scan, etc.)
+- What specific rule or assertion was violated
+- What file and line caused it
+
+### Step 2 — Plan the fix
+For each failure, choose the CORRECT fix:
+- **Lint/format violation**: change the code to comply with the rule.
+  NEVER change linter config, disable rules, or add noqa comments.
+- **Missing dependency**: add it to pyproject.toml and/or requirements.txt.
+  NEVER wrap imports in try/except.
+- **Test failure**: fix the logic bug in the implementation.
+  NEVER weaken the test assertion or delete the test.
+- **Security finding**: fix the insecure pattern in the code.
+  NEVER disable the security rule.
+
+### Step 3 — Apply
+Make the smallest, most targeted fix for each error. Do NOT restructure
+surrounding code, add unrelated improvements, or modify CI config files.
+
+Do NOT run tests — just fix the code.

--- a/aiorchestra/templates/fix_review.md
+++ b/aiorchestra/templates/fix_review.md
@@ -8,4 +8,25 @@ Review feedback:
 
 {errors}
 
-Address the review feedback. Do NOT run tests — just fix the code.
+## Instructions
+
+Follow these steps IN ORDER:
+
+### Step 1 — Understand the feedback
+For each review comment, determine:
+- What specific concern was raised
+- Whether it's about correctness, security, style, or design
+- What file and code section it refers to
+
+### Step 2 — Plan the fix
+For each concern:
+- If it's a bug or security issue: fix the code
+- If it's a style concern: follow the project's existing conventions
+- If it's a design concern: make the minimum change that addresses it
+- NEVER weaken linters, suppress warnings, or modify configs to resolve feedback
+
+### Step 3 — Apply
+Address each review point with the smallest correct change.
+Do NOT restructure surrounding code or add unrelated improvements.
+
+Do NOT run tests — just fix the code.

--- a/aiorchestra/templates/fix_validation.md
+++ b/aiorchestra/templates/fix_validation.md
@@ -8,4 +8,28 @@ The following errors occurred:
 
 {errors}
 
-Fix these errors. Do NOT run tests — just fix the code.
+## Instructions
+
+Follow these steps IN ORDER:
+
+### Step 1 — Diagnose
+Identify what EACH error means. For each error, determine:
+- What rule or check was violated (e.g. ruff E501, missing import, test assertion)
+- What the root cause is in your code
+
+### Step 2 — Plan the fix
+For each error, choose the CORRECT fix:
+- **Lint/format violation**: change the code to comply with the rule.
+  NEVER change linter config, disable rules, or add noqa comments.
+- **Missing dependency**: add it to pyproject.toml and/or requirements.txt.
+  NEVER wrap imports in try/except.
+- **Test failure**: fix the logic bug in the implementation.
+  NEVER weaken the test assertion or delete the test.
+- **Type error**: fix the type mismatch in the code.
+  NEVER add blanket `# type: ignore`.
+
+### Step 3 — Apply
+Make the smallest, most targeted fix for each error. Do NOT restructure
+surrounding code, add unrelated improvements, or modify config files.
+
+Do NOT run tests — just fix the code.

--- a/aiorchestra/templates/review.md
+++ b/aiorchestra/templates/review.md
@@ -4,6 +4,12 @@ Focus on:
 - Bugs or logic errors
 - Security issues
 - Missing edge cases
+- **Shortcut anti-patterns** — flag if the diff:
+  - Wraps imports in try/except ImportError (should add dependency instead)
+  - Changes linter/formatter config (line-length, disabled rules, etc.)
+  - Adds blanket `# noqa` or `# type: ignore` comments
+  - Modifies CI workflows or test thresholds to make checks pass
+  - Weakens or deletes existing tests instead of fixing code
 
 If the code looks good, respond with exactly: LGTM
 If there are issues, describe them clearly.


### PR DESCRIPTION
Three layers of defense against agents weakening configs instead of
fixing code:

1. CLAUDE.md "Bug Fix Rules" section — explicit instructions that
   agents read before acting (never weaken linters, never try/except
   imports, never modify CI to pass checks, diagnose before fixing).

2. Semgrep rules — catch try/except ImportError, blanket noqa, and
   blanket type:ignore at the code analysis level (CI will block).

3. CI config-guard job — flags PRs that touch protected config files
   (pyproject.toml, .semgrep/, .github/workflows/, etc.) with a
   warning so humans review before merging.

https://claude.ai/code/session_01D4FFmsZCAfP6jszeuh8h89