### PR TITLE
Support clarification parsing in OllamaProvider with leading whitespace tolerance

### DIFF
--- a/aiorchestra/ai/_base.py
+++ b/aiorchestra/ai/_base.py
@@ -15,7 +15,7 @@ from dataclasses import dataclass
 log = logging.getLogger(__name__)
 
 _CLARIFICATION_RE = re.compile(
-    r"^NEEDS_CLARIFICATION:\s*(.+)",
+    r"^\s*NEEDS_CLARIFICATION:\s*(.+)",
     re.MULTILINE | re.DOTALL,
 )
 

--- a/aiorchestra/ai/_ollama.py
+++ b/aiorchestra/ai/_ollama.py
@@ -7,7 +7,7 @@ import logging
 import urllib.error
 import urllib.request
 
-from aiorchestra.ai._base import AIProvider, InvokeResult
+from aiorchestra.ai._base import AIProvider, InvokeResult, _parse_clarification
 
 log = logging.getLogger(__name__)
 
@@ -72,7 +72,7 @@ class OllamaProvider(AIProvider):
             return InvokeResult(success=False)
 
         log.debug("Ollama response length: %d chars", len(response_text))
-        return InvokeResult(success=True, output=response_text)
+        return _parse_clarification(response_text)
 
     def available(self) -> bool:
         """Quick health check — can we reach the Ollama server?"""

--- a/tests/test_clarification.py
+++ b/tests/test_clarification.py
@@ -50,6 +50,66 @@ def test_parse_clarification_requires_exact_marker():
     assert result.needs_clarification is False
 
 
+def test_parse_clarification_tolerates_leading_whitespace():
+    # AI might indent the marker (e.g. inside a markdown code block)
+    text = "    NEEDS_CLARIFICATION: Which API version should I target?"
+    result = _parse_clarification(text)
+    assert result.needs_clarification is True
+    assert "API version" in result.clarification_message
+
+
+def test_parse_clarification_multiline_question():
+    text = (
+        "I looked at the issue and found several problems.\n"
+        "NEEDS_CLARIFICATION: The issue mentions both REST and GraphQL.\n"
+        "Which one should I implement?"
+    )
+    result = _parse_clarification(text)
+    assert result.needs_clarification is True
+    assert "REST and GraphQL" in result.clarification_message
+
+
+# ---------------------------------------------------------------------------
+# OllamaProvider: clarification parsing
+# ---------------------------------------------------------------------------
+
+
+def test_ollama_provider_parses_clarification(monkeypatch):
+    """OllamaProvider must route output through _parse_clarification."""
+    import json
+    import urllib.request
+
+    from aiorchestra.ai._ollama import OllamaProvider
+
+    response_body = json.dumps(
+        {"response": "NEEDS_CLARIFICATION: Is this Python 2 or 3?"}
+    ).encode()
+
+    def fake_urlopen(req, timeout=None):
+        class FakeResp:
+            status = 200
+
+            def read(self):
+                return response_body
+
+            def __enter__(self):
+                return self
+
+            def __exit__(self, *a):
+                pass
+
+        return FakeResp()
+
+    monkeypatch.setattr(urllib.request, "urlopen", fake_urlopen)
+
+    provider = OllamaProvider({"endpoint": "http://localhost:11434"})
+    result = provider.run("implement something")
+
+    assert result.needs_clarification is True
+    assert "Python 2 or 3" in result.clarification_message
+    assert result.success is True
+
+
 # ---------------------------------------------------------------------------
 # discover: needs-clarification exclusion
 # ---------------------------------------------------------------------------
@@ -265,6 +325,9 @@ def test_pipeline_defers_issue_on_clarification(monkeypatch, tmp_path):
     )
     monkeypatch.setattr("aiorchestra.pipeline.add_label", lambda repo, number, label: True)
     monkeypatch.setattr("aiorchestra.pipeline.remove_label", lambda repo, number, label: True)
+    monkeypatch.setattr(
+        "aiorchestra.pipeline.swap_label", lambda repo, number, remove, add: True
+    )
 
     pipeline = Pipeline(
         repo="owner/repo",


### PR DESCRIPTION
## Summary
This PR enhances the clarification detection system to handle AI responses that may contain leading whitespace before the `NEEDS_CLARIFICATION` marker, and integrates clarification parsing into the OllamaProvider.

## Key Changes
- **Updated clarification regex pattern** (`aiorchestra/ai/_base.py`): Modified the `_CLARIFICATION_RE` regex to tolerate leading whitespace before the `NEEDS_CLARIFICATION` marker by changing `^NEEDS_CLARIFICATION` to `^\s*NEEDS_CLARIFICATION`. This handles cases where AI models indent the marker (e.g., inside markdown code blocks).

- **Integrated clarification parsing in OllamaProvider** (`aiorchestra/ai/_ollama.py`): Changed the `run()` method to route all responses through `_parse_clarification()` instead of returning raw output. This ensures clarification requests are properly detected and structured.

- **Added comprehensive test coverage** (`tests/test_clarification.py`):
  - `test_parse_clarification_tolerates_leading_whitespace()`: Validates that the parser handles indented markers
  - `test_parse_clarification_multiline_question()`: Ensures multiline clarification messages are captured correctly
  - `test_ollama_provider_parses_clarification()`: Integration test verifying OllamaProvider correctly parses clarification responses
  - Updated existing pipeline test to mock the `swap_label` function

## Implementation Details
The regex change uses `^\s*` to match zero or more whitespace characters at the start of a line (in MULTILINE mode), allowing flexibility in how AI models format their responses while maintaining strict marker matching. The OllamaProvider now returns a structured `InvokeResult` with clarification metadata instead of raw text, enabling downstream pipeline logic to handle clarification requests appropriately.

https://claude.ai/code/session_014rDr4Uphb2WUcwrJPRpXmy