### PR TITLE
Fix spurious 'Unknown review tier' warning for static-analysis

### DIFF
--- a/aiorchestra/stages/review.py
+++ b/aiorchestra/stages/review.py
@@ -263,6 +263,9 @@ def review(
             ok, feedback = _run_cross_model_review(diff, resolved_cfg, issue, repo_root)
         elif name == "human-required":
             ok, feedback = _check_human_required(tier_cfg, issue)
+        elif name == "static-analysis":
+            log.debug("Tier '%s' handled by validate stage, skipping.", name)
+            continue
         else:
             log.warning("Unknown review tier '%s', skipping.", name)
             continue

--- a/tests/test_review.py
+++ b/tests/test_review.py
@@ -312,6 +312,43 @@ def test_review_skips_disabled_tiers(monkeypatch):
     assert not provider.called
 
 
+def test_review_skips_static_analysis_without_warning(monkeypatch, caplog):
+    """static-analysis is handled by validate, so review should skip it silently."""
+    monkeypatch.setattr(
+        rev_mod,
+        "run_command",
+        lambda cmd, cwd=None, logger=None: types.SimpleNamespace(
+            returncode=0, stdout=DIFF, stderr=""
+        ),
+    )
+
+    provider = _patch_provider(monkeypatch, output="LGTM")
+    monkeypatch.setattr(
+        rev_mod,
+        "render_template",
+        lambda name, **kw: "template",
+    )
+
+    config = {
+        "review": {
+            "tiers": [
+                {"name": "static-analysis", "enabled": True, "commands": ["semgrep"]},
+                {"name": "ai-review", "enabled": True, "provider": "claude-code"},
+            ]
+        }
+    }
+
+    import logging
+
+    with caplog.at_level(logging.DEBUG, logger="aiorchestra.stages.review"):
+        ok, feedback = review("owner/repo", "branch", config, issue=ISSUE)
+
+    assert ok
+    assert feedback is None
+    assert "Unknown review tier" not in caplog.text
+    assert "handled by validate stage" in caplog.text
+
+
 def test_review_falls_back_to_legacy_when_no_tiers(monkeypatch):
     """When no tiers are configured, falls back to single AI review."""
     monkeypatch.setattr(


### PR DESCRIPTION
## Summary

- The review stage dispatcher did not recognize `static-analysis` as a known tier name, even though it is defined in default config and intentionally handled by the validate stage
- Added `static-analysis` to the dispatch chain as a recognized-but-skipped tier, logging at DEBUG instead of WARNING
- Added test verifying no spurious warning is emitted and the correct debug message appears

## Test plan

- [x] `pytest tests/test_review.py` — all 34 tests pass, including new `test_review_skips_static_analysis_without_warning`
- [ ] CI passes


Made with [Cursor](https://cursor.com)