### PR TITLE
Fix #49: bug: issue with label "codex" gets implemented by claude instead

### DIFF
--- a/aiorchestra/ai/__init__.py
+++ b/aiorchestra/ai/__init__.py
@@ -11,6 +11,7 @@ from aiorchestra.ai._agents import (
     agent_family_from_config,
     build_agent_branch,
     normalize_agent_family,
+    provider_for_agent,
     resolve_agent,
 )
 from aiorchestra.ai._base import AIProvider, InvokeResult, _parse_clarification
@@ -40,5 +41,6 @@ __all__ = [
     "build_agent_branch",
     "create_provider",
     "normalize_agent_family",
+    "provider_for_agent",
     "resolve_agent",
 ]

--- a/aiorchestra/ai/_agents.py
+++ b/aiorchestra/ai/_agents.py
@@ -6,6 +6,15 @@ from typing import Any
 DEFAULT_AGENT_FAMILY = "claude"
 KNOWN_AGENTS: tuple[str, ...] = ("claude", "codex", "gemini", "jules", "opencode")
 
+# Maps agent family names to the provider id used by the registry.
+_FAMILY_TO_PROVIDER: dict[str, str] = {
+    "claude": "claude-code",
+    "codex": "codex",
+    "gemini": "gemini",
+    "jules": "jules",
+    "opencode": "opencode",
+}
+
 
 def normalize_agent_family(value: str | None) -> str:
     """Collapse provider ids like ``claude-code`` into ``claude``."""
@@ -26,6 +35,11 @@ def normalize_agent_family(value: str | None) -> str:
             break
 
     return normalized or DEFAULT_AGENT_FAMILY
+
+
+def provider_for_agent(family: str) -> str:
+    """Return the provider id for a given agent *family* name."""
+    return _FAMILY_TO_PROVIDER.get(family, family)
 
 
 def agent_family_from_config(config: Mapping[str, Any]) -> str:

--- a/aiorchestra/dispatcher.py
+++ b/aiorchestra/dispatcher.py
@@ -36,22 +36,26 @@ class Dispatcher:
 
         for repo, issues in repo_issues.items():
             log.info("Dispatching %d issue(s) for %s", len(issues), repo)
+
+            # Group issues by resolved agent so each pipeline uses the
+            # correct provider for its issues.
+            by_agent: dict[str, list] = {}
             for issue in issues:
                 agent = resolve_agent(issue.get("labels", []))
                 log.info("  #%d -> %s", issue["number"], agent)
+                by_agent.setdefault(agent, []).append(issue)
 
-            label = resolve_agent(issues[0].get("labels", []))
-
-            pipeline = Pipeline(
-                repo=repo,
-                label=label,
-                config=self.config,
-                config_path=self.config_path,
-                dry_run=self.dry_run,
-                workspace=self.workspace,
-            )
-            result = pipeline.run(issues=issues)
-            if result != 0:
-                return result
+            for label, agent_issues in by_agent.items():
+                pipeline = Pipeline(
+                    repo=repo,
+                    label=label,
+                    config=self.config,
+                    config_path=self.config_path,
+                    dry_run=self.dry_run,
+                    workspace=self.workspace,
+                )
+                result = pipeline.run(issues=agent_issues)
+                if result != 0:
+                    return result
 
         return 0

--- a/aiorchestra/pipeline.py
+++ b/aiorchestra/pipeline.py
@@ -10,7 +10,8 @@ import os
 import time
 
 from aiorchestra.ai import agent_family_from_config, build_agent_branch, provider_for_agent
-from aiorchestra.config import load_config
+from aiorchestra.ai._agents import KNOWN_AGENTS
+from aiorchestra.config import _deep_merge, load_config
 from aiorchestra.stages._shell import run_command
 from aiorchestra.stages.clarification import request_clarification
 from aiorchestra.stages.discover import discover_issues
@@ -340,7 +341,7 @@ class Pipeline:
         # Override the AI provider when the pipeline label indicates a
         # specific agent family (e.g. issue labelled "codex" must use
         # the codex provider, not the default from config).
-        if self.label:
+        if self.label and self.label in KNOWN_AGENTS:
             expected_provider = provider_for_agent(self.label)
             ai_section = config.get("ai", {})
             if ai_section.get("provider", "claude-code") != expected_provider:
@@ -350,7 +351,7 @@ class Pipeline:
                     expected_provider,
                     self.label,
                 )
-                config.setdefault("ai", {})["provider"] = expected_provider
+                config = _deep_merge(config, {"ai": {"provider": expected_provider}})
 
         # Log resolved config at startup.
         ai_cfg = config.get("ai", {})

--- a/aiorchestra/pipeline.py
+++ b/aiorchestra/pipeline.py
@@ -9,7 +9,7 @@ import typing
 import os
 import time
 
-from aiorchestra.ai import agent_family_from_config, build_agent_branch
+from aiorchestra.ai import agent_family_from_config, build_agent_branch, provider_for_agent
 from aiorchestra.config import load_config
 from aiorchestra.stages._shell import run_command
 from aiorchestra.stages.clarification import request_clarification
@@ -336,6 +336,21 @@ class Pipeline:
 
         log.info("Working in %s", repo_root)
         config = load_config(self.config_path, repo_root=repo_root)
+
+        # Override the AI provider when the pipeline label indicates a
+        # specific agent family (e.g. issue labelled "codex" must use
+        # the codex provider, not the default from config).
+        if self.label:
+            expected_provider = provider_for_agent(self.label)
+            ai_section = config.get("ai", {})
+            if ai_section.get("provider", "claude-code") != expected_provider:
+                log.info(
+                    "Overriding provider %s -> %s (label=%s)",
+                    ai_section.get("provider", "claude-code"),
+                    expected_provider,
+                    self.label,
+                )
+                config.setdefault("ai", {})["provider"] = expected_provider
 
         # Log resolved config at startup.
         ai_cfg = config.get("ai", {})

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,6 +21,9 @@ dev = [
 [project.scripts]
 aiorchestra = "aiorchestra.cli:main"
 
+[tool.setuptools.packages.find]
+include = ["aiorchestra*"]
+
 [tool.ruff]
 line-length = 100
 


### PR DESCRIPTION
Automated implementation for #49.

## Issue description

issue #33 for story_writer repo (https://github.com/ironharvy/story_writer) was picked up and implemented but claude was used instead

## Changes

```
aiorchestra/ai/__init__.py |  2 ++
 aiorchestra/ai/_agents.py  | 14 ++++++++++++++
 aiorchestra/dispatcher.py  | 32 ++++++++++++++++++--------------
 aiorchestra/pipeline.py    | 17 ++++++++++++++++-
 4 files changed, 50 insertions(+), 15 deletions(-)
```

**Labels:** `bug`, `claude`, `aiorchestra`

Closes #49