### PR TITLE
Fix Codex CLI provider to use `codex exec` subcommand

### DIFF
--- a/aiorchestra/ai/_codex.py
+++ b/aiorchestra/ai/_codex.py
@@ -2,24 +2,35 @@
 
 from __future__ import annotations
 
+import logging
+
 from aiorchestra.ai._cli import CLIProvider
+
+log = logging.getLogger(__name__)
+
+_SANDBOX_MODES = frozenset({"read-only", "workspace-write", "danger-full-access"})
 
 
 class CodexProvider(CLIProvider):
-    """Invokes the ``codex`` CLI in quiet (non-interactive) mode.
+    """Invokes the ``codex exec`` subcommand for non-interactive execution.
 
-    Codex runs locally like Claude Code.  In ``full-auto`` approval mode it
-    edits files without interactive confirmation (network is disabled by the
-    CLI in this mode).
+    ``codex exec`` replaces the former ``codex --quiet`` interface.
+    In ``--full-auto`` mode the CLI uses *workspace-write* sandboxing and
+    auto-approves tool calls (network is disabled by the CLI in this mode).
     """
 
     _cli_name = "codex"
 
     def _build_command(self, prompt: str) -> list[str]:
-        cmd: list[str] = ["codex", "--quiet"]
+        cmd: list[str] = ["codex", "exec"]
 
         approval = self._config.get("approval_mode", "full-auto")
-        cmd.extend(["--approval-mode", approval])
+        if approval == "full-auto":
+            cmd.append("--full-auto")
+        elif approval in _SANDBOX_MODES:
+            cmd.extend(["--sandbox", approval])
+        else:
+            log.warning("Unknown approval_mode %r — omitting flag", approval)
 
         model = self._config.get("model")
         if model:

--- a/tests/test_codex.py
+++ b/tests/test_codex.py
@@ -11,7 +11,7 @@ def _make_provider(**overrides):
 
 
 def test_codex_basic_invocation(monkeypatch):
-    """Codex is invoked with --quiet and --approval-mode full-auto by default."""
+    """Codex is invoked via ``exec --full-auto`` by default."""
     captured = {}
 
     def fake_run(cmd, *, capture_output=False, text=False, cwd=None):
@@ -26,9 +26,8 @@ def test_codex_basic_invocation(monkeypatch):
 
     assert result.success
     assert result.output == "done\n"
-    assert captured["cmd"][:2] == ["codex", "--quiet"]
-    assert "--approval-mode" in captured["cmd"]
-    assert "full-auto" in captured["cmd"]
+    assert captured["cmd"][:2] == ["codex", "exec"]
+    assert "--full-auto" in captured["cmd"]
     assert "fix the bug" in captured["cmd"]
     assert captured["cwd"] == "/tmp/repo"
 
@@ -51,8 +50,26 @@ def test_codex_custom_model(monkeypatch):
     assert captured["cmd"][idx + 1] == "o4-mini"
 
 
-def test_codex_custom_approval_mode(monkeypatch):
-    """Approval mode can be overridden."""
+def test_codex_sandbox_approval_mode(monkeypatch):
+    """Sandbox-style approval modes map to --sandbox."""
+    captured = {}
+
+    def fake_run(cmd, **kwargs):
+        captured["cmd"] = cmd
+        return subprocess.CompletedProcess(cmd, 0, stdout="ok", stderr="")
+
+    monkeypatch.setattr("aiorchestra.ai._cli.subprocess.run", fake_run)
+
+    provider = _make_provider(approval_mode="workspace-write")
+    provider.run("hello")
+
+    assert "--full-auto" not in captured["cmd"]
+    idx = captured["cmd"].index("--sandbox")
+    assert captured["cmd"][idx + 1] == "workspace-write"
+
+
+def test_codex_unknown_approval_mode(monkeypatch):
+    """Unknown approval modes are omitted with a warning."""
     captured = {}
 
     def fake_run(cmd, **kwargs):
@@ -64,8 +81,8 @@ def test_codex_custom_approval_mode(monkeypatch):
     provider = _make_provider(approval_mode="auto-edit")
     provider.run("hello")
 
-    idx = captured["cmd"].index("--approval-mode")
-    assert captured["cmd"][idx + 1] == "auto-edit"
+    assert "--full-auto" not in captured["cmd"]
+    assert "--sandbox" not in captured["cmd"]
 
 
 def test_codex_failure(monkeypatch):


### PR DESCRIPTION
## Summary

- The Codex CLI removed the `--quiet` top-level flag and `--approval-mode` option, breaking the provider with `error: unexpected argument '--quiet' found`.
- Updated `CodexProvider._build_command` to use `codex exec` with `--full-auto` (default) and `--sandbox <mode>` for granular sandbox control.
- Updated and expanded tests to cover the new command shape, sandbox mode mapping, and unknown mode handling.

## Test plan

- [x] All 8 Codex-specific tests pass (`pytest tests/test_codex.py -v`)
- [x] Full test suite passes (236 tests)
- [x] No linter errors introduced

Made with [Cursor](https://cursor.com)