### PR TITLE
Fix package discovery and add assertion to review test

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,6 +21,9 @@ dev = [
 [project.scripts]
 aiorchestra = "aiorchestra.cli:main"
 
+[tool.setuptools.packages.find]
+include = ["aiorchestra*"]
+
 [tool.ruff]
 line-length = 100
 

--- a/tests/test_review.py
+++ b/tests/test_review.py
@@ -345,6 +345,7 @@ def test_review_skips_static_analysis_without_warning(monkeypatch, caplog):
 
     assert ok
     assert feedback is None
+    assert provider.called
     assert "Unknown review tier" not in caplog.text
     assert "handled by validate stage" in caplog.text
 


### PR DESCRIPTION
## Summary
This PR makes two small but important fixes: ensuring proper package discovery in the build configuration and adding a missing assertion to verify provider behavior in tests.

## Key Changes
- **Package Discovery**: Added `[tool.setuptools.packages.find]` configuration to `pyproject.toml` with `include = ["aiorchestra*"]` to ensure all aiorchestra packages are properly discovered during installation
- **Test Assertion**: Added `assert provider.called` to `test_review_skips_static_analysis_without_warning` to verify that the provider was actually invoked during the test, improving test coverage and preventing false positives

## Implementation Details
The setuptools package discovery configuration ensures that the build system correctly identifies and includes all packages matching the `aiorchestra*` pattern, which is important for proper package distribution and installation.

The additional assertion in the test strengthens the validation by confirming not just the outcome (ok and feedback values) but also that the expected provider interaction occurred.

https://claude.ai/code/session_01NQkgnYyJRyFfHmnJyazmyT