### PR TITLE
Generalize implement.md prompt for non-coding roles

### DIFF
--- a/POC_DAEDALUS_DO_NOT_MERGE.md
+++ b/POC_DAEDALUS_DO_NOT_MERGE.md
@@ -1,0 +1,19 @@
+# ⚠️ PoC branch — do not merge, do not delete
+
+This branch (`claude/daedalus-dspy-poc-WBs5e`) carries experimental
+changes to AIOrchestra needed by the DaedalusDSPy proof-of-concept.
+
+See `ironharvy/DaedalusDSPy` → `POC.md` on the matching branch for
+context and rationale.
+
+**Before merging or deleting this branch:** confirm the PoC is either
+abandoned or graduated into a proper design. Do not clean this up on
+autopilot.
+
+Current experimental changes on this branch:
+
+- `aiorchestra/templates/implement.md` — softened from coder-only wording
+  to a role-agnostic prompt that accepts documentation-only deliverables.
+  This is required so non-coding roles (CEO, BA, PM, etc.) can satisfy
+  the pipeline's "must produce a diff" invariant by committing markdown
+  artifacts under `docs/`.

--- a/aiorchestra/templates/implement.md
+++ b/aiorchestra/templates/implement.md
@@ -1,15 +1,25 @@
-Implement the following GitHub issue.
+Work on the following GitHub issue.
 
 Issue #{number}: {title}
 
 {body}
 {osint_context}{comments_section}
-Do NOT run tests — just implement the changes.
+Read the issue body carefully and act accordingly. The issue may describe
+a coding task, a documentation task, or a planning task depending on the
+role it assigns you. Whatever the role, you must leave at least one
+committed change in the worktree — the orchestrator needs a diff to open
+a pull request. If the role is non-coding (CEO, BA, PM, Tech Lead,
+Researcher, QA, DevOps), commit your deliverable as a markdown file
+under `docs/` unless the issue says otherwise. If the role is coding,
+implement the changes directly.
+
+Do not run tests as part of this step — a later pipeline stage handles
+validation.
 
 ## Clarification protocol
 
 If the issue description is ambiguous, contradictory, or missing critical
-information that prevents you from implementing a correct solution, do NOT
+information that prevents you from producing a correct deliverable, do NOT
 guess. Instead, output a single line starting with the marker below, followed
 by a concise question for the issue author:
 
@@ -20,5 +30,5 @@ orchestrator will post your question as a comment on the issue and pause
 work until the author responds.
 
 Only use this when the ambiguity would lead to a materially wrong
-implementation. Minor stylistic uncertainties should be resolved using your
+deliverable. Minor stylistic uncertainties should be resolved using your
 best judgement.


### PR DESCRIPTION
## Summary

Softens the `implement.md` prompt template to support non-coding roles (CEO, BA, PM, Tech Lead, Researcher, QA, DevOps) in the AIOrchestra pipeline. Previously, the prompt was coder-centric and assumed code implementation as the only valid deliverable. This change allows roles to satisfy the "must produce a diff" invariant by committing markdown artifacts under `docs/` when appropriate.

## Key Changes

- **Reframed task language**: Changed "Implement the following GitHub issue" to "Work on the following GitHub issue" to reflect broader scope beyond coding
- **Role-aware instructions**: Added explicit guidance that issues may describe coding, documentation, or planning tasks depending on assigned role
- **Non-coding deliverable path**: Clarified that non-coding roles should commit markdown files under `docs/` unless the issue specifies otherwise
- **Updated clarification protocol**: Changed "prevents you from implementing" to "prevents you from producing a correct deliverable" to be role-agnostic
- **Test guidance**: Clarified that test execution is deferred to a later pipeline stage

## Context

This is a proof-of-concept branch (`claude/daedalus-dspy-poc-WBs5e`) supporting the DaedalusDSPy experimental work. See the matching branch in `ironharvy/DaedalusDSPy` for full context. **Do not merge or delete this branch without confirming the PoC status.**

https://claude.ai/code/session_01EADbsTKBKAkmUcnTC4uL2a