### PR TITLE
Document stage contracts, review tiers, and refresh stale sections

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,6 +45,44 @@ A lightweight, always-running orchestrator that watches for GitHub issues and dr
 
 On failure at Validate, CI, or Review — the AI is re-invoked with the error output appended to the prompt. A configurable retry cap prevents infinite loops.
 
+### Stage contracts
+
+What each stage consumes, does, and produces. Protocol types live in
+`aiorchestra/stages/types.py`.
+
+| Stage | Entry function | Intake | Produces | External side effects |
+|-------|----------------|--------|----------|-----------------------|
+| **Discover** | `discover_issues(repo, label, …)` / `discover_all_issues(owner, label, …)` | repo (or owner) + label, optional issue number | `list[IssueData]` (single repo) or `dict[repo → list[IssueData]]` (multi-repo); issues carrying any `SKIP_LABELS` are filtered out | Read-only `gh issue list` / `gh issue view` / `gh search issues` |
+| **Prepare** | `prepare_environment(repo, branch, workspace)` | `owner/repo`, branch name, workspace root | Absolute path to the repo working copy, or `None` on failure | Clones/fetches repo into `~/.aiorchestra/workspaces/<repo>`, creates/checks out branch, sets up `.venv` and installs deps |
+| **OSINT** | `enrich_issue(issue, osint_config)` | Issue + `osint` config block | `str` — OSINT context ready to splice into the implement prompt (empty when disabled or no targets) | Runs local CLI tools (`whois`, `dig`, `curl`, optionally `nmap`); hits a local Ollama endpoint for summarisation. No cloud tokens. |
+| **Implement** | `implement(issue, config, prompt_name, error_text, repo_root, osint_context, repo)` | Issue, full pipeline config, OSINT context, optional error text from a prior failed attempt | `InvokeResult` — `success`, `stdout`, `stderr`, `returncode`, optional `clarification` parsed from a `NEEDS_CLARIFICATION:` marker | Spends cloud AI tokens; the AI agent edits files under `repo_root`. No git or GitHub calls. |
+| **Validate** | `validate(config, repo_root)` | Pipeline config (reads `test.lint_command`, `test.command`, `review.tiers[static-analysis]`), working copy | `FeedbackResult` — `(passed: bool, feedback: str \| None)`; `feedback` is the combined lint/test/static-analysis error output used to prime the next implement retry | Runs lint/test/static-analysis tools (T0 + T1) on local files only |
+| **Publish** | `publish(repo, branch, issue, repo_root, pr_url)` | `owner/repo`, branch, issue, working copy, optional existing PR URL | `PublishResult` — PR URL on success, `None` if the branch has no diff or push/PR creation fails | `git add -A`, `git commit`, `git push -u origin <branch>`, `gh pr create` / updates existing PR |
+| **CI Watch** | `wait_for_ci(pr_url, config)` | PR URL, `ci` config (timeout, poll_interval) | `FeedbackResult` — `(passed, failure_logs)` | Polls `gh pr checks` until every check concludes or `ci.timeout` elapses. Read-only. |
+| **Review** | `review(repo, branch, config, issue, repo_root)` | `review.tiers` config, diff vs. `origin/main`, issue metadata | `FeedbackResult` — short-circuits on the first failing tier; `feedback` feeds the `fix_review` prompt | T3 AI review (primary provider) and T4 cross-model review spend tokens; T5 human-required reads labels. No GitHub writes. |
+| **Clarification** | `request_clarification(repo, issue, message)` | `owner/repo`, issue, question from the agent's `NEEDS_CLARIFICATION:` marker | `bool` — `True` only when both the comment and the label were applied | `gh issue comment` posts the question; `needs-clarification` label is added so discover skips the issue on future runs |
+
+> `IssueData`, `FeedbackResult`, `PublishResult`, and the `Protocol` classes
+> (`ImplementFn`, `ValidationFn`, `RemoteCheckFn`, `PublishFn`) are defined in
+> [`aiorchestra/stages/types.py`](aiorchestra/stages/types.py). Label
+> constants (`LABEL_WORKING`, `LABEL_NEEDS_CLARIFICATION`,
+> `LABEL_AWAITING_REVIEW`, `LABEL_FAILED`) live in
+> [`aiorchestra/stages/labels.py`](aiorchestra/stages/labels.py).
+
+### Review tiers
+
+The review stage runs ordered tiers and short-circuits on the first failure.
+T0 and T1 execute earlier (in **Validate**), so the Review stage itself only
+runs T3–T5:
+
+| Tier | Name | Runs in | What it checks |
+|------|------|---------|----------------|
+| T0 | lint + tests | Validate | `test.lint_command`, `test.command` |
+| T1 | `static-analysis` | Validate | Tools listed under `review.tiers[static-analysis].commands` (e.g. `semgrep`, `bandit`); missing tools on PATH are skipped |
+| T3 | `ai-review` | Review | Primary AI reviews the diff vs. `origin/main` using the `review` template |
+| T4 | `cross-model-review` / `cross-agent-review` | Review | A second provider cross-checks the diff; by default `pick_cross_agent()` picks a different family from the implementation provider |
+| T5 | `human-required` | Review | Gate on a human-approval label; keeps the issue in the `awaiting-review` state |
+
 ### Agent clarification protocol
 
 When the AI agent encounters an ambiguous or underspecified issue, it can signal this by emitting a `NEEDS_CLARIFICATION:` marker in its output instead of guessing:
@@ -57,14 +95,20 @@ The pipeline detects this, posts the question as a comment on the GitHub issue, 
 
 ### Issue lifecycle labels
 
-The pipeline uses GitHub labels to track issue state and prevent collisions across concurrent runs:
+The pipeline uses GitHub labels to track issue state and prevent collisions
+across concurrent runs. All four are defined as constants in
+`aiorchestra/stages/labels.py` and are collectively the `SKIP_LABELS` set
+that the discover stage filters out.
 
 | Label | Meaning | Added | Removed |
 |-------|---------|-------|---------|
 | `agent-working` | An agent has claimed this issue | Before processing starts | On completion, failure, or deferral |
-| `needs-clarification` | Waiting on human input | When agent signals ambiguity | Manually, after the human responds |
+| `needs-clarification` | Waiting on human input | When the agent emits `NEEDS_CLARIFICATION:` | Manually, after the human responds |
+| `awaiting-review` | Blocked on the T5 human-required review tier | When the review stage hits a `human-required` tier | Manually, when a reviewer approves |
+| `agent-failed` | Pipeline terminated unsuccessfully | On unrecoverable failure (retries exhausted, publish error, …) | Manually, after investigation |
 
-Discovery skips issues carrying either label.
+Discovery skips issues carrying any of these labels so concurrent runs
+never double-claim the same issue.
 
 ### Parallel processing
 
@@ -206,16 +250,27 @@ CLI `--poll-interval` overrides this value.
 
 ### Agent routing
 
-The active AI provider determines the required agent-family label. Provider IDs are normalized into families:
+The active AI provider determines the required agent-family label. Provider
+IDs are normalized into families by `normalize_agent_family()` in
+`aiorchestra/ai/_agents.py`:
 
-| Provider | Family | Required label |
-|----------|--------|----------------|
-| `claude-code`, `claude-api` | `claude` | `claude` |
-| `codex`, `codex-v2` | `codex` | `codex` |
-| `jules` | `jules` | `jules` |
-| `opencode` | `opencode` | `opencode` |
+| Provider id | Family | Required issue label | Invocation mode |
+|-------------|--------|----------------------|-----------------|
+| `claude-code` | `claude` | `claude` | Local `claude` CLI (`--print`) |
+| `codex` | `codex` | `codex` | Local `codex exec --full-auto` |
+| `gemini` | `gemini` | `gemini` | Local `gemini -p --yolo` |
+| `opencode` | `opencode` | `opencode` | Local `opencode run --yes` |
+| `jules` | `jules` | `jules` | Remote async session via `jules remote new` |
+| `ollama` | *(not a dispatch target)* | — | Local HTTP; used for OSINT summarisation and as a cross-model reviewer |
 
-`resolve_agent()` scans issue labels for a known agent name — first match wins. If no label matches, the configured default is used.
+`resolve_agent()` scans issue labels for a known agent name (first match
+wins). If no label matches, the configured default from `ai.provider` is
+used. `KNOWN_AGENTS` is the source of truth: `("claude", "codex", "gemini",
+"jules", "opencode")`.
+
+Ollama isn't a dispatch target because it can't edit files on its own — it's
+a text-in/text-out LLM. It's wired in as a local summariser for the OSINT
+stage and is available as a T4 cross-model reviewer.
 
 ## Target repo integration
 
@@ -238,7 +293,9 @@ your-project/
 | 1. Target repo | `.aiorchestra/templates/*.md` | `.aiorchestra/config.yaml` |
 | 2. AIOrchestra defaults | `aiorchestra/templates/*.md` | Built-in `DEFAULTS` |
 
-**Built-in templates:** `implement`, `fix_validation`, `fix_ci`, `review`, `fix_review`, `osint_summarize` — each uses `{variable}` placeholders filled by the pipeline.
+**Built-in templates:** `implement`, `fix_validation`, `fix_ci`, `review`,
+`review_cross_model`, `fix_review`, `rework`, `osint_summarize` — each uses
+`{variable}` placeholders filled by the pipeline.
 
 **Agent instructions** (CLAUDE.md, AGENTS.md, etc.) belong in the target repo, not AIOrchestra. They describe that codebase's conventions and are read directly by the AI agent.
 
@@ -247,38 +304,48 @@ your-project/
 ```
 aiorchestra/
 ├── __init__.py
-├── cli.py              # CLI entry point (run, dispatch, --watch loop)
-├── config.py           # Config loader (3-layer merge)
-├── agents.py           # Agent family normalization & routing
-├── dispatcher.py       # Multi-repo issue discovery & dispatch
-├── pipeline.py         # Stage runner / state machine (fork-per-issue)
-├── _logging.py         # Colored terminal log formatter
-├── ai/
+├── _logging.py           # Colored terminal log formatter
+├── _sentry.py            # Optional Sentry error reporting
+├── cli.py                # CLI entry point (run, dispatch, --watch loop)
+├── config.py             # Config loader (3-layer merge: defaults → repo → explicit)
+├── dispatcher.py         # Multi-repo issue discovery & fan-out
+├── pipeline.py           # Stage runner / state machine (fork-per-issue)
+├── ai/                   # Strategy pattern — one file per provider
+│   ├── __init__.py       # Public API: AIProvider, InvokeResult, create_provider, …
+│   ├── _agents.py        # Agent family normalization & routing (KNOWN_AGENTS)
+│   ├── _base.py          # AIProvider ABC + InvokeResult + NEEDS_CLARIFICATION parsing
+│   ├── _cli.py           # CLIProvider intermediate base for CLI-backed providers
+│   ├── _registry.py      # create_provider() factory
+│   ├── _claude_code.py   # Claude Code CLI (local, `claude --print`)
+│   ├── _codex.py         # OpenAI Codex CLI (local, `codex exec`)
+│   ├── _gemini.py        # Google Gemini CLI (local, `gemini -p`)
+│   ├── _jules.py         # Google Jules (remote async session)
+│   ├── _ollama.py        # Ollama local LLM (HTTP) — used by OSINT & cross-review
+│   └── _opencode.py      # OpenCode CLI (local, `opencode run`)
+├── stages/               # One module per pipeline stage; contracts in types.py
 │   ├── __init__.py
-│   ├── claude.py       # Claude Code CLI wrapper, InvokeResult
-│   └── ollama.py       # Ollama local LLM provider
-├── stages/
-│   ├── __init__.py
-│   ├── _shell.py       # Shared subprocess helpers
-│   ├── types.py        # Shared types & protocols
-│   ├── labels.py       # GitHub label management (agent-working, needs-clarification)
-│   ├── clarification.py # Defer ambiguous issues with a question comment
-│   ├── discover.py     # Find labeled issues (single repo or multi-repo)
-│   ├── prepare.py      # Git + env setup
-│   ├── osint.py        # OSINT enrichment (shell tools + Ollama)
-│   ├── implement.py    # AI implementation invocation
-│   ├── validate.py     # Tests + linting
-│   ├── publish.py      # Push + PR creation
-│   ├── ci.py           # CI status polling
-│   └── review.py       # AI code review
-└── templates/
-    ├── __init__.py     # Template loader with override resolution
-    ├── implement.md    # Default implementation prompt (includes clarification protocol)
-    ├── osint_summarize.md # OSINT summarisation prompt for local Ollama
-    ├── fix_validation.md
-    ├── fix_ci.md
-    ├── review.md
-    └── fix_review.md
+│   ├── _shell.py         # ALL subprocess calls funnel through run_command()
+│   ├── types.py          # IssueData, FeedbackResult, PublishResult, Protocol classes
+│   ├── labels.py         # GitHub label helpers + lifecycle constants
+│   ├── discover.py       # Find labeled issues (single-repo or multi-repo)
+│   ├── prepare.py        # Clone/fetch + checkout + venv + deps
+│   ├── osint.py          # OSINT enrichment (shell tools + Ollama summariser)
+│   ├── clarification.py  # Defer ambiguous issues with a question comment
+│   ├── implement.py      # Invokes the AI provider with the rendered prompt
+│   ├── validate.py       # T0 lint + tests, T1 static analysis
+│   ├── publish.py        # Commit + push + `gh pr create` (or update)
+│   ├── ci.py             # Poll `gh pr checks` until completion
+│   └── review.py         # T3 ai-review, T4 cross-model-review, T5 human-required
+└── templates/            # Prompt templates, overridable from target repo
+    ├── __init__.py       # Template loader with override resolution
+    ├── implement.md      # Default implementation prompt (clarification protocol baked in)
+    ├── fix_validation.md # Retry prompt after a Validate failure
+    ├── fix_ci.md         # Retry prompt after a CI failure
+    ├── review.md         # Primary AI review (T3)
+    ├── review_cross_model.md # Cross-model review (T4)
+    ├── fix_review.md     # Retry prompt after a Review failure
+    ├── rework.md         # Rework prompt for human-requested changes
+    └── osint_summarize.md # Local summarisation prompt for Ollama
 ```
 
 ## Running as a service


### PR DESCRIPTION
Adds an explicit per-stage I/O contract table (Intake / Produces / Side
effects) so contributors can see at a glance what each pipeline stage
consumes, does, and returns, with pointers into stages/types.py and
stages/labels.py.

Refreshes sections that had drifted from the code:
- Project-structure tree now matches the real layout (_base/_cli/_registry
  factory split, all six provider modules, _sentry, review_cross_model +
  rework templates).
- Agent-routing table adds gemini, distinguishes local-CLI vs. remote
  invocation, and clarifies that ollama is not a dispatch target.
- Issue-lifecycle labels table adds awaiting-review and agent-failed to
  match SKIP_LABELS.
- New Review tiers table covers T0-T5.
- Built-in templates list includes review_cross_model and rework.