### PR TITLE
Add wait-for-issue.sh script to poll GitHub for labeled issues

### DIFF
--- a/scripts/wait-for-issue.sh
+++ b/scripts/wait-for-issue.sh
@@ -1,0 +1,49 @@
+#!/usr/bin/env bash
+# Block until a GitHub issue matching a label appears, then print it as JSON.
+#
+# Usage:
+#   wait-for-issue.sh <repo> <label> [poll_seconds] [max_wait_seconds]
+#
+# Exits:
+#   0  — match found; issue JSON on stdout
+#   75 — max_wait reached without a match (EX_TEMPFAIL); re-run to keep waiting
+#   1  — gh/jq failure or bad arguments
+#
+# Why max_wait defaults to 540s: Claude Code's Bash tool caps a single call at
+# 600s, so the script self-terminates under that ceiling. A parent loop (shell,
+# Claude, cron) can re-invoke on exit 75 to wait indefinitely.
+
+set -euo pipefail
+
+REPO="${1:?repo required (owner/name)}"
+LABEL="${2:?label required}"
+POLL="${3:-30}"
+MAX_WAIT="${4:-540}"
+
+command -v gh >/dev/null || { echo "gh not found on PATH" >&2; exit 1; }
+command -v jq >/dev/null || { echo "jq not found on PATH" >&2; exit 1; }
+
+deadline=$(( $(date +%s) + MAX_WAIT ))
+
+while :; do
+  out=$(gh issue list \
+    --repo "$REPO" \
+    --label "$LABEL" \
+    --state open \
+    --json number,title,body,labels,assignees,comments \
+    --limit 1)
+
+  if [[ "$(jq 'length' <<<"$out")" -gt 0 ]]; then
+    jq '.[0]' <<<"$out"
+    exit 0
+  fi
+
+  now=$(date +%s)
+  if (( now >= deadline )); then
+    echo "no matching issue for repo=$REPO label=$LABEL after ${MAX_WAIT}s" >&2
+    exit 75
+  fi
+
+  remaining=$(( deadline - now ))
+  sleep "$(( POLL < remaining ? POLL : remaining ))"
+done


### PR DESCRIPTION
## Summary
Add a new bash utility script that polls a GitHub repository for open issues matching a specific label, blocking until one is found or a timeout is reached.

## Key Changes
- **New script**: `scripts/wait-for-issue.sh` — a polling utility that:
  - Queries GitHub issues via the `gh` CLI filtered by label and open state
  - Polls at configurable intervals (default 30s) until a match is found
  - Respects a maximum wait time (default 540s) to stay under execution limits
  - Returns matching issue as JSON on stdout (exit 0) or timeout signal (exit 75)
  - Validates required dependencies (`gh` and `jq`) upfront
  - Supports re-invocation by parent processes to wait indefinitely

## Notable Implementation Details
- Uses `gh issue list` with JSON output for structured querying
- Implements deadline-based timeout logic to gracefully handle max_wait expiration
- Intelligently sleeps for the minimum of poll interval or remaining time to avoid overshooting deadline
- Exit code 75 (EX_TEMPFAIL) signals timeout for parent loop retry logic
- Designed to work within Claude Code's 600s Bash tool execution ceiling
- Includes comprehensive usage documentation and exit code reference in script header

https://claude.ai/code/session_0155xfuLv6rNxwKJvcAfZFaa