### PR TITLE
Use DISPATCH_LABEL instead of config label in gh query

### DIFF
--- a/aiorchestra/stages/discover.py
+++ b/aiorchestra/stages/discover.py
@@ -49,7 +49,7 @@ def discover_issues(
             "--repo",
             repo,
             "--label",
-            label,
+            DISPATCH_LABEL,
             "--state",
             "open",
             "--json",

--- a/tests/test_discover.py
+++ b/tests/test_discover.py
@@ -260,6 +260,41 @@ def test_discover_all_skips_issues_with_skip_labels(monkeypatch):
     assert result["owner/repo-a"][0]["number"] == 2
 
 
+def test_discover_uses_dispatch_label_for_gh_query(monkeypatch):
+    """The gh query must use DISPATCH_LABEL, not the config label."""
+    captured_cmds = []
+
+    def fake_run(cmd, logger=None):
+        captured_cmds.append(cmd)
+        return _completed_process(
+            [
+                {
+                    "number": 1,
+                    "title": "Build landing page",
+                    "body": "",
+                    "labels": [{"name": "aiorchestra"}, {"name": "codex"}],
+                    "assignees": [],
+                }
+            ]
+        )
+
+    monkeypatch.setattr("aiorchestra.stages.discover.run_command", fake_run)
+
+    issues = discover_issues(
+        "owner/flower_shop",
+        "claude",
+        agent_label="codex",
+        retries=1,
+        delay=0,
+    )
+
+    assert len(issues) == 1
+    assert issues[0]["number"] == 1
+    assert "--label" in captured_cmds[0]
+    label_idx = captured_cmds[0].index("--label")
+    assert captured_cmds[0][label_idx + 1] == "aiorchestra"
+
+
 def test_discover_normalizes_comments(monkeypatch):
     """Issue comments should be extracted and normalized."""
     monkeypatch.setattr(


### PR DESCRIPTION
## Summary
Fixed the `discover_issues` function to use the `DISPATCH_LABEL` constant when querying GitHub issues, rather than using the agent-specific label passed via configuration.

## Changes
- Updated the `gh` command in `discover_issues()` to query by `DISPATCH_LABEL` instead of the `label` parameter
- Added test case `test_discover_uses_dispatch_label_for_gh_query()` to verify the correct label is used in the GitHub query

## Details
The discovery process should filter issues by a dispatch label (likely a standard label used across all agents) rather than agent-specific labels. This ensures consistent issue discovery behavior regardless of the agent's configured label. The agent-specific label is still used for filtering results after retrieval, but the initial GitHub query now uses the dispatch label as intended.

https://claude.ai/code/session_01DiyCMV6yQWxzH3JBEgNB5o