### PR TITLE
Auto-route issues to the agent implied by their labels

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,20 +82,23 @@ pip install -e .
 # Run continuously — scan all your repos every 5 minutes
 aiorchestra dispatch --watch
 
-# Watch a single repo
-aiorchestra run --repo owner/repo --label claude --watch
+# Watch a single repo — each issue auto-routes to the agent named in its labels
+aiorchestra run --repo owner/repo --watch
 
 # Custom poll interval (seconds)
 aiorchestra dispatch --watch --poll-interval 120
 
-# One-shot: process all issues labeled "claude" in a repo
-aiorchestra run --repo owner/repo --label claude
+# One-shot: process every aiorchestra-labeled issue, routing per-issue
+aiorchestra run --repo owner/repo
+
+# One-shot: pin a specific agent family (claude, codex, gemini, jules, opencode)
+aiorchestra run --repo owner/repo --label codex
 
 # One-shot: process a specific issue
 aiorchestra run --repo owner/repo --issue 42
 
 # Dry run — show what would happen without executing
-aiorchestra run --repo owner/repo --label claude --dry-run
+aiorchestra run --repo owner/repo --dry-run
 
 # Scan all your repos for "aiorchestra"-labeled issues (one-shot)
 aiorchestra dispatch

--- a/aiorchestra/cli.py
+++ b/aiorchestra/cli.py
@@ -57,7 +57,14 @@ def build_parser() -> argparse.ArgumentParser:
 
     run = sub.add_parser("run", help="Process issues and drive the AI pipeline")
     run.add_argument("--repo", required=True, help="GitHub repo (owner/repo)")
-    run.add_argument("--label", default=None, help="Issue label to filter by")
+    run.add_argument(
+        "--label",
+        default=None,
+        help=(
+            "Pin a specific agent family (claude, codex, gemini, jules, opencode). "
+            "When omitted, each issue is auto-routed to the agent implied by its labels."
+        ),
+    )
     run.add_argument("--issue", type=int, default=None, help="Specific issue number")
     run.add_argument("--config", default=None, help="Path to config YAML")
     run.add_argument(
@@ -163,7 +170,7 @@ def main(argv: list[str] | None = None) -> int:
         _init_sentry(config)
         pipeline = Pipeline(
             repo=args.repo,
-            label=args.label or config.get("label", "claude"),
+            label=args.label or config.get("label"),
             issue_number=args.issue,
             config=config,
             config_path=args.config,

--- a/aiorchestra/config.py
+++ b/aiorchestra/config.py
@@ -11,7 +11,6 @@ from pathlib import Path
 import yaml
 
 DEFAULTS = {
-    "label": "claude",
     "ai": {
         "provider": "claude-code",
         "model": "claude-opus-4-6",

--- a/aiorchestra/pipeline.py
+++ b/aiorchestra/pipeline.py
@@ -16,7 +16,11 @@ from aiorchestra._sentry import (
     set_context,
     set_tag,
 )
-from aiorchestra.ai import agent_family_from_config, build_agent_branch, provider_for_agent
+from aiorchestra.ai import (
+    build_agent_branch,
+    provider_for_agent,
+    resolve_agent,
+)
 from aiorchestra.ai._agents import KNOWN_AGENTS
 from aiorchestra.config import _deep_merge, load_config
 from aiorchestra.stages._shell import StageTimer, has_diff_from_main, run_command
@@ -88,7 +92,7 @@ class Pipeline:
     def __init__(
         self,
         repo: str,
-        label: str,
+        label: str | None,
         config: PipelineConfig,
         config_path: str | None = None,
         issue_number: int | None = None,
@@ -116,11 +120,14 @@ class Pipeline:
         ensure_labels(self.repo, dry_run=self.dry_run)
 
         if issues is None:
+            if self.label is None:
+                return self._run_auto_route()
+
             issues = discover_issues(
                 self.repo,
                 self.label,
                 self.issue_number,
-                agent_label=agent_family_from_config(self.config),
+                agent_label=self.label,
             )
         if not issues:
             log.info("No issues found.")
@@ -129,6 +136,57 @@ class Pipeline:
         if self.parallel:
             return self._run_parallel(issues)
         return self._run_sequential(issues)
+
+    # ------------------------------------------------------------------
+    # Auto-route: no --label given — resolve per issue from its labels
+    # ------------------------------------------------------------------
+
+    def _run_auto_route(self) -> int:
+        """Discover every aiorchestra-labeled issue and fan out by agent label.
+
+        When the caller did not pin a specific agent family, each issue is
+        routed to the agent implied by its own labels (via ``resolve_agent``).
+        Issues are grouped per agent so each spawned pipeline invokes the
+        correct provider and produces correctly-named branches.
+        """
+        issues = discover_issues(
+            self.repo,
+            label=None,
+            issue_number=self.issue_number,
+            agent_label=None,
+        )
+        if not issues:
+            log.info("No issues found.")
+            return 0
+
+        by_agent: dict[str, list[IssueData]] = {}
+        for issue in issues:
+            agent = resolve_agent(issue.get("labels", []))
+            log.info("  #%d -> %s", issue["number"], agent)
+            by_agent.setdefault(agent, []).append(issue)
+
+        for agent, agent_issues in by_agent.items():
+            expected_provider = provider_for_agent(agent)
+            child_config = _deep_merge(
+                self.config,
+                {"ai": {"provider": expected_provider}},
+            )
+            child = Pipeline(
+                repo=self.repo,
+                label=agent,
+                config=child_config,
+                config_path=self.config_path,
+                issue_number=self.issue_number,
+                dry_run=self.dry_run,
+                workspace=self.workspace,
+                parallel=self.parallel,
+                review_only=self.review_only,
+            )
+            result = child.run(issues=agent_issues)
+            if result != 0:
+                return result
+
+        return 0
 
     # ------------------------------------------------------------------
     # Sequential mode (original behaviour, useful for single-issue runs)

--- a/aiorchestra/pipeline.py
+++ b/aiorchestra/pipeline.py
@@ -165,12 +165,19 @@ class Pipeline:
             log.info("  #%d -> %s", issue["number"], agent)
             by_agent.setdefault(agent, []).append(issue)
 
+        current_provider = self.config.get("ai", {}).get("provider")
         for agent, agent_issues in by_agent.items():
             expected_provider = provider_for_agent(agent)
             child_config = _deep_merge(
                 self.config,
                 {"ai": {"provider": expected_provider}},
             )
+            # Each provider CLI expects its own model names — an inherited
+            # `ai.model` like `claude-opus-4-6` would be rejected by codex,
+            # gemini, etc.  Drop it when we're switching providers so the
+            # child CLI falls back to its own default.
+            if expected_provider != current_provider:
+                child_config.setdefault("ai", {}).pop("model", None)
             child = Pipeline(
                 repo=self.repo,
                 label=agent,
@@ -512,6 +519,11 @@ class Pipeline:
                     self.label,
                 )
                 config = _deep_merge(config, {"ai": {"provider": expected_provider}})
+                # Inherited `ai.model` is tied to the previous provider and
+                # will be rejected by a different CLI (e.g. codex refuses
+                # claude-opus-4-6).  Drop it so the new provider uses its
+                # own default unless the user set a compatible model.
+                config.setdefault("ai", {}).pop("model", None)
 
         # Log resolved config at startup.
         ai_cfg = config.get("ai", {})

--- a/aiorchestra/stages/discover.py
+++ b/aiorchestra/stages/discover.py
@@ -18,7 +18,7 @@ DISPATCH_LABEL = "aiorchestra"
 
 def discover_issues(
     repo: str,
-    label: str,
+    label: str | None = None,
     issue_number: int | None = None,
     delay: int = 60,
     retries: int = 3,
@@ -27,8 +27,14 @@ def discover_issues(
     """Fetch issues from GitHub using the gh CLI.
 
     Returns issue dicts enriched with normalized label and assignee names.
+
+    If both ``label`` and ``agent_label`` are falsy, no agent-family filter is
+    applied and every ``aiorchestra``-labeled ready issue is returned.  This
+    enables auto-routing where the caller resolves the agent from each issue's
+    own labels (see ``resolve_agent``).
     """
-    required_label = normalize_agent_family(agent_label or label)
+    filter_source = agent_label or label
+    required_label = normalize_agent_family(filter_source) if filter_source else None
 
     if issue_number:
         cmd = [
@@ -82,10 +88,15 @@ def discover_issues(
         return []
 
     issues = [_normalize_issue(issue) for issue in data]
-    eligible_issues = [issue for issue in issues if required_label in issue.get("labels", [])]
-    if not eligible_issues:
-        log.error("No issues matched required agent label: %s", required_label)
-        return []
+    if required_label is None:
+        eligible_issues = issues
+    else:
+        eligible_issues = [
+            issue for issue in issues if required_label in issue.get("labels", [])
+        ]
+        if not eligible_issues:
+            log.error("No issues matched required agent label: %s", required_label)
+            return []
 
     # Filter out issues that are already in progress or waiting on a human.
     ready_issues = [

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -5,7 +5,8 @@ from aiorchestra.config import load_config, _deep_merge, _merge_named_lists
 
 def test_defaults_returned_when_no_file():
     config = load_config("/nonexistent/path.yaml")
-    assert config["label"] == "claude"
+    # No default `label` — absence enables auto-routing per issue's agent label.
+    assert "label" not in config
     assert config["ai"]["max_retries"] == 3
     assert "branch_prefix" not in config
 

--- a/tests/test_discover.py
+++ b/tests/test_discover.py
@@ -295,6 +295,49 @@ def test_discover_uses_dispatch_label_for_gh_query(monkeypatch):
     assert captured_cmds[0][label_idx + 1] == "aiorchestra"
 
 
+def test_discover_without_filter_returns_all_ready_issues(monkeypatch):
+    """Without an agent label, every non-skipped issue should be returned."""
+    monkeypatch.setattr(
+        "aiorchestra.stages.discover.run_command",
+        lambda cmd, logger=None: _completed_process(
+            [
+                {
+                    "number": 1,
+                    "title": "Codex issue",
+                    "body": "",
+                    "labels": [{"name": "aiorchestra"}, {"name": "codex"}],
+                    "assignees": [],
+                },
+                {
+                    "number": 2,
+                    "title": "Claude issue",
+                    "body": "",
+                    "labels": [{"name": "aiorchestra"}, {"name": "claude"}],
+                    "assignees": [],
+                },
+                {
+                    "number": 3,
+                    "title": "Unlabelled (dispatch only)",
+                    "body": "",
+                    "labels": [{"name": "aiorchestra"}],
+                    "assignees": [],
+                },
+                {
+                    "number": 4,
+                    "title": "Already reviewed",
+                    "body": "",
+                    "labels": [{"name": "aiorchestra"}, {"name": "awaiting-review"}],
+                    "assignees": [],
+                },
+            ]
+        ),
+    )
+
+    issues = discover_issues("owner/repo", retries=1, delay=0)
+
+    assert [i["number"] for i in issues] == [1, 2, 3]
+
+
 def test_discover_normalizes_comments(monkeypatch):
     """Issue comments should be extracted and normalized."""
     monkeypatch.setattr(

--- a/tests/test_dispatcher.py
+++ b/tests/test_dispatcher.py
@@ -298,3 +298,116 @@ def test_pipeline_run_with_presupplied_issues(monkeypatch, tmp_path):
     assert ("implement", 20) in calls
     assert ("publish", 10) in calls
     assert ("publish", 20) in calls
+
+
+# ---------------------------------------------------------------------------
+# Pipeline auto-route: no --label given → group by each issue's agent label
+# ---------------------------------------------------------------------------
+
+
+def test_pipeline_auto_route_groups_by_agent_label(monkeypatch):
+    """When label is None, the pipeline groups issues by resolved agent and
+    spawns a child pipeline per group with the corresponding provider."""
+    from aiorchestra.pipeline import Pipeline
+
+    monkeypatch.setattr(
+        "aiorchestra.pipeline.ensure_labels",
+        lambda repo, dry_run=False: None,
+    )
+
+    discovered = [
+        {"number": 1, "title": "Codex task", "labels": ["aiorchestra", "codex"]},
+        {"number": 2, "title": "Claude task", "labels": ["aiorchestra", "claude"]},
+        {"number": 3, "title": "Bare task", "labels": ["aiorchestra"]},
+    ]
+
+    def fake_discover(repo, label=None, issue_number=None, agent_label=None, **_):
+        assert label is None
+        assert agent_label is None
+        return list(discovered)
+
+    monkeypatch.setattr("aiorchestra.pipeline.discover_issues", fake_discover)
+
+    spawned: list[dict] = []
+
+    original_run = Pipeline.run
+
+    def spy_run(self, issues=None):
+        if self.label is None:
+            return original_run(self, issues=issues)
+        spawned.append(
+            {
+                "label": self.label,
+                "provider": self.config.get("ai", {}).get("provider"),
+                "issue_numbers": [i["number"] for i in (issues or [])],
+            }
+        )
+        return 0
+
+    monkeypatch.setattr(Pipeline, "run", spy_run)
+
+    pipeline = Pipeline(
+        repo="owner/repo",
+        label=None,
+        config={"ai": {"provider": "claude-code"}},
+        parallel=False,
+    )
+
+    assert pipeline.run() == 0
+
+    by_label = {entry["label"]: entry for entry in spawned}
+    assert set(by_label.keys()) == {"codex", "claude"}
+    assert by_label["codex"]["provider"] == "codex"
+    assert by_label["codex"]["issue_numbers"] == [1]
+    assert by_label["claude"]["provider"] == "claude-code"
+    assert by_label["claude"]["issue_numbers"] == [2, 3]
+
+
+def test_pipeline_auto_route_stops_on_failure(monkeypatch):
+    """A failing child pipeline aborts the auto-route loop."""
+    from aiorchestra.pipeline import Pipeline
+
+    monkeypatch.setattr(
+        "aiorchestra.pipeline.ensure_labels",
+        lambda repo, dry_run=False: None,
+    )
+    monkeypatch.setattr(
+        "aiorchestra.pipeline.discover_issues",
+        lambda *args, **kwargs: [
+            {"number": 1, "title": "A", "labels": ["aiorchestra", "codex"]},
+            {"number": 2, "title": "B", "labels": ["aiorchestra", "claude"]},
+        ],
+    )
+
+    call_count = {"n": 0}
+
+    original_run = Pipeline.run
+
+    def spy_run(self, issues=None):
+        if self.label is None:
+            return original_run(self, issues=issues)
+        call_count["n"] += 1
+        return 1
+
+    monkeypatch.setattr(Pipeline, "run", spy_run)
+
+    pipeline = Pipeline(repo="owner/repo", label=None, config={}, parallel=False)
+    assert pipeline.run() == 1
+    assert call_count["n"] == 1
+
+
+def test_pipeline_auto_route_no_issues(monkeypatch):
+    """Auto-route returns 0 when discovery finds nothing."""
+    from aiorchestra.pipeline import Pipeline
+
+    monkeypatch.setattr(
+        "aiorchestra.pipeline.ensure_labels",
+        lambda repo, dry_run=False: None,
+    )
+    monkeypatch.setattr(
+        "aiorchestra.pipeline.discover_issues",
+        lambda *args, **kwargs: [],
+    )
+
+    pipeline = Pipeline(repo="owner/repo", label=None, config={}, parallel=False)
+    assert pipeline.run() == 0

--- a/tests/test_dispatcher.py
+++ b/tests/test_dispatcher.py
@@ -335,10 +335,12 @@ def test_pipeline_auto_route_groups_by_agent_label(monkeypatch):
     def spy_run(self, issues=None):
         if self.label is None:
             return original_run(self, issues=issues)
+        ai_cfg = self.config.get("ai", {})
         spawned.append(
             {
                 "label": self.label,
-                "provider": self.config.get("ai", {}).get("provider"),
+                "provider": ai_cfg.get("provider"),
+                "model": ai_cfg.get("model"),
                 "issue_numbers": [i["number"] for i in (issues or [])],
             }
         )
@@ -349,7 +351,7 @@ def test_pipeline_auto_route_groups_by_agent_label(monkeypatch):
     pipeline = Pipeline(
         repo="owner/repo",
         label=None,
-        config={"ai": {"provider": "claude-code"}},
+        config={"ai": {"provider": "claude-code", "model": "claude-opus-4-6"}},
         parallel=False,
     )
 
@@ -359,8 +361,13 @@ def test_pipeline_auto_route_groups_by_agent_label(monkeypatch):
     assert set(by_label.keys()) == {"codex", "claude"}
     assert by_label["codex"]["provider"] == "codex"
     assert by_label["codex"]["issue_numbers"] == [1]
+    # Model must be dropped when switching providers — codex would reject
+    # claude-opus-4-6 inherited from the parent config.
+    assert by_label["codex"]["model"] is None
     assert by_label["claude"]["provider"] == "claude-code"
     assert by_label["claude"]["issue_numbers"] == [2, 3]
+    # Provider stayed the same, so the claude-specific model is preserved.
+    assert by_label["claude"]["model"] == "claude-opus-4-6"
 
 
 def test_pipeline_auto_route_stops_on_failure(monkeypatch):


### PR DESCRIPTION
## Summary

- `aiorchestra run --repo X` (no `--label`) now fans out each `aiorchestra`-labeled issue to the agent family named in its own labels (`claude`, `codex`, `gemini`, `jules`, `opencode`) and injects the matching provider into that child pipeline's config, mirroring what `dispatch` does across repos.
- `discover_issues` skips the agent-family filter when neither `label` nor `agent_label` is given, so the new auto-route path sees every ready issue.
- Fixes a latent bug where `Pipeline.run` filtered discovery by the config's `ai.provider` rather than `self.label` — `--label codex` was a no-op when `ai.provider` stayed at the default `claude-code`.
- CLI no longer defaults `--label` to `claude`; explicit pinning still works.

## Motivation

Running `aiorchestra run --repo ironharvy/flower_shop -vv` against an issue tagged `aiorchestra` + `codex` used to exit with `No issues matched required agent label: claude` because the CLI silently defaulted to `claude`. With this change the issue is picked up and routed to the `codex` provider automatically.

## Test plan

- [x] `pytest` — 262 passed (added `test_discover_without_filter_returns_all_ready_issues` and three `test_pipeline_auto_route_*` cases covering grouping, failure propagation, and empty discovery)
- [ ] Manual: `aiorchestra run --repo ironharvy/flower_shop -vv` picks up issue #1 (labeled `codex`) and dispatches to the codex provider

Made with [Cursor](https://cursor.com)