### PR TITLE
Validate smarter: skip Python tools for non-Python repos, add --log-file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
+.tmp/
 workspaces/
 # Byte-compiled / optimized / DLL files
 __pycache__/

--- a/aiorchestra/_logging.py
+++ b/aiorchestra/_logging.py
@@ -85,12 +85,19 @@ def _use_json(stream: object) -> bool:
     return not (hasattr(stream, "isatty") and stream.isatty())
 
 
-def setup_logging(verbosity: int = 0, *, verbose: bool = False) -> None:
+def setup_logging(
+    verbosity: int = 0,
+    *,
+    verbose: bool = False,
+    log_file: str | None = None,
+) -> None:
     """Configure root logger.
 
     Args:
         verbosity: Number of -v flags (0=WARNING, 1=INFO, 2=DEBUG, 3=firehose).
         verbose:   Legacy boolean flag — maps to verbosity=1 when True.
+        log_file:  Optional path for a plain-text file handler.  Falls back to
+                   ``$AIORCHESTRA_LOG_FILE`` / ``$LOG_FILE`` when omitted.
     """
     if verbose and verbosity == 0:
         verbosity = 1
@@ -112,18 +119,30 @@ def setup_logging(verbosity: int = 0, *, verbose: bool = False) -> None:
     root.setLevel(level)
     root.addHandler(stderr_handler)
 
-    # Optional file handler — always JSON
-    log_file = os.environ.get("LOG_FILE", "")
-    if log_file:
+    resolved_log_file = (
+        log_file
+        or os.environ.get("AIORCHESTRA_LOG_FILE", "")
+        or os.environ.get("LOG_FILE", "")
+    )
+    if resolved_log_file:
         try:
-            file_handler = logging.FileHandler(log_file, encoding="utf-8")
+            parent = os.path.dirname(resolved_log_file)
+            if parent:
+                os.makedirs(parent, exist_ok=True)
+            file_handler = logging.FileHandler(resolved_log_file, encoding="utf-8")
             file_handler.setLevel(level)
+            # File handler uses JSON so structured fields survive forks and
+            # are easy to parse after the run.
             file_handler.setFormatter(JSONFormatter())
             root.addHandler(file_handler)
-        except OSError:
-            logging.warning("Could not open log file %s, file logging disabled", log_file)
+            logging.getLogger(__name__).info("Logging to file: %s", resolved_log_file)
+        except OSError as exc:
+            logging.warning(
+                "Could not open log file %s (%s) — file logging disabled",
+                resolved_log_file,
+                exc,
+            )
 
-    # Suppress noisy third-party loggers unless firehose (-vvv)
     if verbosity < 3:
         for name in _NOISY_LOGGERS:
             logging.getLogger(name).setLevel(logging.WARNING)

--- a/aiorchestra/cli.py
+++ b/aiorchestra/cli.py
@@ -86,6 +86,14 @@ def build_parser() -> argparse.ArgumentParser:
         help="Verbosity: -v INFO, -vv DEBUG, -vvv firehose",
     )
     run.add_argument(
+        "--log-file",
+        default=None,
+        help=(
+            "Write logs to this file in addition to stderr. "
+            "Overrides $AIORCHESTRA_LOG_FILE."
+        ),
+    )
+    run.add_argument(
         "--watch", action="store_true", help="Run continuously, polling for new issues"
     )
     run.add_argument(
@@ -119,6 +127,14 @@ def build_parser() -> argparse.ArgumentParser:
         help="Verbosity: -v INFO, -vv DEBUG, -vvv firehose",
     )
     dispatch.add_argument(
+        "--log-file",
+        default=None,
+        help=(
+            "Write logs to this file in addition to stderr. "
+            "Overrides $AIORCHESTRA_LOG_FILE."
+        ),
+    )
+    dispatch.add_argument(
         "--watch", action="store_true", help="Run continuously, polling for new issues"
     )
     dispatch.add_argument(
@@ -145,6 +161,14 @@ def build_parser() -> argparse.ArgumentParser:
         default=0,
         help="Verbosity: -v INFO, -vv DEBUG, -vvv firehose",
     )
+    setup.add_argument(
+        "--log-file",
+        default=None,
+        help=(
+            "Write logs to this file in addition to stderr. "
+            "Overrides $AIORCHESTRA_LOG_FILE."
+        ),
+    )
 
     return parser
 
@@ -163,7 +187,10 @@ def main(argv: list[str] | None = None) -> int:
         parser.print_help()
         return 1
 
-    setup_logging(verbosity=getattr(args, "verbose", 0))
+    setup_logging(
+        verbosity=getattr(args, "verbose", 0),
+        log_file=getattr(args, "log_file", None),
+    )
 
     if args.command == "run":
         config = load_config(args.config)

--- a/aiorchestra/config.py
+++ b/aiorchestra/config.py
@@ -28,8 +28,9 @@ DEFAULTS = {
                 "name": "static-analysis",
                 "enabled": True,
                 "commands": [
-                    "semgrep --config=auto --quiet .",
-                    "bandit -r . -q",
+                    "semgrep --config=auto --quiet "
+                    "--exclude .venv --exclude node_modules --exclude .git .",
+                    "bandit -r . -q -x ./.venv,./node_modules,./.git",
                 ],
             },
             {

--- a/aiorchestra/pipeline.py
+++ b/aiorchestra/pipeline.py
@@ -277,8 +277,13 @@ class Pipeline:
             _sentry_flush()
             os._exit(0)
 
-        except Exception:
-            log.exception("Unhandled error processing issue #%d", number)
+        except Exception as exc:
+            log.exception(
+                "Unhandled %s processing issue #%d: %s",
+                type(exc).__name__,
+                number,
+                exc,
+            )
             capture_exception()
             swap_label(self.repo, number, LABEL_WORKING, LABEL_FAILED)
             _sentry_flush()
@@ -322,8 +327,13 @@ class Pipeline:
         add_label(self.repo, number, LABEL_WORKING)
         try:
             result = self._process_issue(issue)
-        except Exception:
-            log.exception("Unhandled error processing issue #%d", number)
+        except Exception as exc:
+            log.exception(
+                "Unhandled %s processing issue #%d: %s",
+                type(exc).__name__,
+                number,
+                exc,
+            )
             capture_exception()
             swap_label(self.repo, number, LABEL_WORKING, LABEL_FAILED)
             return False

--- a/aiorchestra/stages/implement.py
+++ b/aiorchestra/stages/implement.py
@@ -10,6 +10,35 @@ from aiorchestra.templates import render_template
 
 log = logging.getLogger(__name__)
 
+# Cap the size of error feedback we forward into a fix-up prompt. Large
+# static-analysis dumps (e.g. bandit scanning a venv) can explode the prompt
+# past CLI argv limits and overwhelm the model.  24 KiB keeps enough context
+# for humans and models while staying well below common shell/CLI caps.
+_MAX_ERROR_TEXT_BYTES = 24 * 1024
+
+
+def _truncate_error_text(error_text: str) -> str:
+    """Trim oversized validation/CI feedback to a safe size for the prompt."""
+    encoded = error_text.encode("utf-8", errors="replace")
+    if len(encoded) <= _MAX_ERROR_TEXT_BYTES:
+        return error_text
+
+    head = _MAX_ERROR_TEXT_BYTES // 2
+    tail = _MAX_ERROR_TEXT_BYTES - head
+    prefix = encoded[:head].decode("utf-8", errors="replace")
+    suffix = encoded[-tail:].decode("utf-8", errors="replace")
+    omitted = len(encoded) - _MAX_ERROR_TEXT_BYTES
+    marker = (
+        f"\n\n... [truncated {omitted} bytes of error output — showing first "
+        f"{head} and last {tail} bytes] ...\n\n"
+    )
+    log.warning(
+        "Truncated error feedback from %d to %d bytes before sending to AI",
+        len(encoded),
+        _MAX_ERROR_TEXT_BYTES,
+    )
+    return prefix + marker + suffix
+
 
 def _build_prompt(
     issue: IssueData,
@@ -39,7 +68,7 @@ def _build_prompt(
         "comments_section": comments_section,
     }
     if error_text is not None:
-        template_kwargs["errors"] = error_text
+        template_kwargs["errors"] = _truncate_error_text(error_text)
 
     return render_template(
         prompt_name,

--- a/aiorchestra/stages/validate.py
+++ b/aiorchestra/stages/validate.py
@@ -2,16 +2,56 @@
 
 import logging
 import shutil
+from pathlib import Path
 
 from aiorchestra.stages._shell import StageTimer, run_command
 from aiorchestra.stages.types import FeedbackResult, PipelineConfig
 
 log = logging.getLogger(__name__)
 
+# Directories to skip when probing for project source files. Mirrors the
+# default excludes wired into the static-analysis commands.
+_IGNORED_DIRS = {".venv", "venv", ".git", "node_modules", "__pycache__", ".tox"}
+
+# pytest exit code 5 == "no tests were collected" — not a real failure for
+# projects that simply don't have tests (e.g. a static site).
+_PYTEST_NO_TESTS_COLLECTED = 5
+
+# Python-centric tools that only make sense when the repo has *.py sources.
+_PYTHON_ONLY_TOOLS = frozenset({"ruff", "pytest", "mypy", "bandit", "pyright", "pylint"})
+
+
+def _has_python_sources(repo_root: str | None) -> bool:
+    """Return True if *repo_root* contains any tracked ``*.py`` file.
+
+    Walks the tree but ignores venvs, VCS metadata, caches, and node_modules
+    so a stray `.venv/` from `_setup_venv` doesn't make a static-only repo
+    look like a Python project.
+    """
+    if not repo_root:
+        return True  # Be permissive when no root is given (legacy callers).
+
+    root = Path(repo_root)
+    if not root.exists():
+        return True
+
+    for path in root.rglob("*.py"):
+        if any(part in _IGNORED_DIRS for part in path.relative_to(root).parts):
+            continue
+        return True
+    return False
+
+
+def _is_python_tool(cmd: str) -> bool:
+    tool = cmd.split(maxsplit=1)[0] if cmd else ""
+    return tool in _PYTHON_ONLY_TOOLS
+
 
 def _run_static_analysis(
     review_cfg: PipelineConfig,
     repo_root: str | None = None,
+    *,
+    python_project: bool = True,
 ) -> list[str]:
     """Run static-analysis tier commands (T1). Returns list of error strings."""
     tiers = review_cfg.get("tiers", [])
@@ -24,6 +64,10 @@ def _run_static_analysis(
         tool_name = cmd.split()[0]
         if not shutil.which(tool_name):
             log.info("Static analysis tool '%s' not found on PATH, skipping", tool_name)
+            continue
+
+        if not python_project and _is_python_tool(cmd):
+            log.info("Skipping %s — repo has no Python sources", tool_name)
             continue
 
         log.info("Running static analysis: %s", cmd)
@@ -41,24 +85,40 @@ def validate(config: PipelineConfig, repo_root: str | None = None) -> FeedbackRe
     review_cfg = config.get("review", {})
     errors = []
 
+    python_project = _has_python_sources(repo_root)
+    if not python_project:
+        log.info("No Python sources detected — skipping ruff/pytest/bandit/etc.")
+
     # T0: Linter
     lint_cmd = test_cfg.get("lint_command", "ruff check .")
-    log.info("Running linter: %s", lint_cmd)
-    with timer.step("lint"):
-        result = run_command(lint_cmd, cwd=repo_root, logger=log)
-        if result.returncode != 0:
-            errors.append(f"Lint errors:\n{result.stdout}\n{result.stderr}")
+    if python_project or not _is_python_tool(lint_cmd):
+        log.info("Running linter: %s", lint_cmd)
+        with timer.step("lint"):
+            result = run_command(lint_cmd, cwd=repo_root, logger=log)
+            if result.returncode != 0:
+                errors.append(f"Lint errors:\n{result.stdout}\n{result.stderr}")
 
     # T0: Tests
     test_cmd = test_cfg.get("command", "pytest")
-    log.info("Running tests: %s", test_cmd)
-    with timer.step("tests"):
-        result = run_command(test_cmd, cwd=repo_root, logger=log)
-        if result.returncode != 0:
-            errors.append(f"Test errors:\n{result.stdout}\n{result.stderr}")
+    if python_project or not _is_python_tool(test_cmd):
+        log.info("Running tests: %s", test_cmd)
+        with timer.step("tests"):
+            result = run_command(test_cmd, cwd=repo_root, logger=log)
+            # pytest returns 5 when no tests were collected; treat that as a
+            # pass so repos without a test suite don't trip validation.
+            is_pytest = test_cmd.split(maxsplit=1)[0] == "pytest"
+            ok = result.returncode == 0 or (
+                is_pytest and result.returncode == _PYTEST_NO_TESTS_COLLECTED
+            )
+            if not ok:
+                errors.append(f"Test errors:\n{result.stdout}\n{result.stderr}")
+            elif is_pytest and result.returncode == _PYTEST_NO_TESTS_COLLECTED:
+                log.info("pytest collected no tests — treating as pass")
 
     # T1: Static analysis (semgrep, bandit, etc.)
-    errors.extend(_run_static_analysis(review_cfg, repo_root))
+    errors.extend(
+        _run_static_analysis(review_cfg, repo_root, python_project=python_project)
+    )
 
     log.info("[validate] completed in %.1fs (%s)", timer.total, timer.summary())
 

--- a/tests/test_implement.py
+++ b/tests/test_implement.py
@@ -1,0 +1,46 @@
+"""Tests for the implement stage (prompt assembly, feedback truncation)."""
+
+from aiorchestra.stages import implement as impl_mod
+from aiorchestra.stages.implement import _MAX_ERROR_TEXT_BYTES, _truncate_error_text
+
+
+def test_truncate_short_error_text_unchanged():
+    text = "only a few bytes of feedback"
+    assert _truncate_error_text(text) == text
+
+
+def test_truncate_long_error_text_keeps_head_and_tail():
+    body = "A" * (_MAX_ERROR_TEXT_BYTES * 3)
+    prefix = "START-MARKER:"
+    suffix = ":END-MARKER"
+    oversized = prefix + body + suffix
+
+    result = _truncate_error_text(oversized)
+
+    assert len(result.encode("utf-8")) < len(oversized.encode("utf-8"))
+    # Both ends survive so the AI still sees real context on either side.
+    assert result.startswith(prefix)
+    assert result.endswith(suffix)
+    # And the middle is replaced with a human-readable truncation marker.
+    assert "truncated" in result
+
+
+def test_build_prompt_truncates_error_text(monkeypatch):
+    captured = {}
+
+    def fake_render(name, **kwargs):
+        captured["kwargs"] = kwargs
+        return "rendered"
+
+    monkeypatch.setattr(impl_mod, "render_template", fake_render)
+
+    huge = "X" * (_MAX_ERROR_TEXT_BYTES * 2)
+    impl_mod._build_prompt(
+        {"number": 1, "title": "t", "body": ""},
+        prompt_name="fix_validation",
+        error_text=huge,
+    )
+
+    assert "errors" in captured["kwargs"]
+    assert len(captured["kwargs"]["errors"].encode("utf-8")) <= _MAX_ERROR_TEXT_BYTES + 512
+    assert "truncated" in captured["kwargs"]["errors"]

--- a/tests/test_logging.py
+++ b/tests/test_logging.py
@@ -213,6 +213,25 @@ def test_setup_logging_firehose_allows_noisy(monkeypatch):
     root.handlers.clear()
 
 
+def test_setup_logging_file_handler_cli_arg(monkeypatch, tmp_path):
+    """The explicit log_file argument wins over environment variables."""
+    monkeypatch.delenv("LOG_LEVEL", raising=False)
+    monkeypatch.delenv("LOG_FILE", raising=False)
+    monkeypatch.delenv("AIORCHESTRA_LOG_FILE", raising=False)
+    log_path = str(tmp_path / "subdir" / "aiorchestra.log")
+    root = _fresh_root()
+    setup_logging(verbosity=1, log_file=log_path)
+    logger = logging.getLogger("aiorchestra.test.cli")
+    logger.info("cli arg message")
+    for h in root.handlers:
+        h.flush()
+    root.handlers.clear()
+
+    assert os.path.exists(log_path)
+    lines = open(log_path).readlines()
+    assert any("cli arg message" in line for line in lines)
+
+
 def test_setup_logging_file_handler(monkeypatch, tmp_path):
     monkeypatch.delenv("LOG_LEVEL", raising=False)
     log_path = str(tmp_path / "aiorchestra.log")

--- a/tests/test_validate.py
+++ b/tests/test_validate.py
@@ -3,7 +3,11 @@
 import types
 
 from aiorchestra.stages import validate as val_mod
-from aiorchestra.stages.validate import _run_static_analysis, validate
+from aiorchestra.stages.validate import (
+    _has_python_sources,
+    _run_static_analysis,
+    validate,
+)
 
 
 def test_validate_passes_when_lint_and_tests_succeed(monkeypatch):
@@ -147,3 +151,95 @@ def test_validate_includes_static_analysis_errors(monkeypatch):
     assert not ok
     assert "bandit" in errors
     assert "B101" in errors
+
+
+# ---------------------------------------------------------------------------
+# Python-source detection and skip-when-non-python behaviour
+# ---------------------------------------------------------------------------
+
+
+def test_has_python_sources_detects_py_files(tmp_path):
+    (tmp_path / "module.py").write_text("print('hi')\n")
+    assert _has_python_sources(str(tmp_path)) is True
+
+
+def test_has_python_sources_ignores_py_in_venv(tmp_path):
+    """A stray `.venv/` from _setup_venv must not make a static repo look
+    like a Python project."""
+    (tmp_path / "index.html").write_text("<html></html>\n")
+    venv = tmp_path / ".venv" / "lib" / "python3.12" / "site-packages"
+    venv.mkdir(parents=True)
+    (venv / "pygments.py").write_text("pass\n")
+    assert _has_python_sources(str(tmp_path)) is False
+
+
+def test_has_python_sources_none_is_permissive():
+    """Legacy callers that pass repo_root=None should not be silenced."""
+    assert _has_python_sources(None) is True
+
+
+def test_validate_skips_python_tools_for_non_python_repo(monkeypatch, tmp_path):
+    """ruff/pytest/bandit must be skipped when the repo has no Python files."""
+    (tmp_path / "index.html").write_text("<html></html>\n")
+    (tmp_path / "styles.css").write_text("body { }\n")
+
+    invoked = []
+
+    def fake_run(cmd, *, cwd=None, check=False, shell=None, logger=None):
+        cmd_str = cmd if isinstance(cmd, str) else " ".join(cmd)
+        invoked.append(cmd_str)
+        return types.SimpleNamespace(returncode=0, stdout="", stderr="")
+
+    monkeypatch.setattr(val_mod, "run_command", fake_run)
+    monkeypatch.setattr(val_mod.shutil, "which", lambda tool: f"/usr/bin/{tool}")
+
+    config = {
+        "test": {"command": "pytest", "lint_command": "ruff check ."},
+        "review": {
+            "tiers": [
+                {
+                    "name": "static-analysis",
+                    "enabled": True,
+                    "commands": [
+                        "bandit -r .",
+                        "semgrep --config=auto --quiet .",
+                    ],
+                }
+            ]
+        },
+    }
+
+    ok, errors = validate(config, repo_root=str(tmp_path))
+
+    assert ok
+    assert errors is None
+    # Neither ruff, pytest, nor bandit should have been invoked.
+    assert not any("ruff" in c for c in invoked)
+    assert not any(c.startswith("pytest") for c in invoked)
+    assert not any("bandit" in c for c in invoked)
+    # semgrep is language-agnostic, so it still runs.
+    assert any("semgrep" in c for c in invoked)
+
+
+def test_validate_treats_pytest_no_tests_collected_as_pass(monkeypatch, tmp_path):
+    """pytest exit code 5 (no tests collected) must not trip validation."""
+    (tmp_path / "app.py").write_text("def add(a, b):\n    return a + b\n")
+
+    def fake_run(cmd, *, cwd=None, check=False, shell=None, logger=None):
+        cmd_str = cmd if isinstance(cmd, str) else " ".join(cmd)
+        if cmd_str.startswith("pytest"):
+            return types.SimpleNamespace(
+                returncode=5, stdout="no tests ran", stderr=""
+            )
+        return types.SimpleNamespace(returncode=0, stdout="", stderr="")
+
+    monkeypatch.setattr(val_mod, "run_command", fake_run)
+    monkeypatch.setattr(val_mod.shutil, "which", lambda tool: f"/usr/bin/{tool}")
+
+    ok, errors = validate(
+        {"test": {"command": "pytest", "lint_command": "ruff check ."}},
+        repo_root=str(tmp_path),
+    )
+
+    assert ok
+    assert errors is None


### PR DESCRIPTION
## Summary

Follow-up to #62 (auto-routing).  A run against `ironharvy/flower_shop` — a static HTML/CSS repo — produced thousands of bandit findings scraped from the `.venv/` that `_setup_venv` creates inside every cloned workspace.  That output was then sent to codex as the `fix_validation` prompt body, blowing up the CLI and masking the real failure behind a generic "Unhandled error".

This PR makes validation appropriate to the repo and adds first-class file logging.

### Validation is smarter

- `validate()` detects whether the repo has Python sources (ignoring `.venv`, `venv`, `.git`, `node_modules`, `__pycache__`, `.tox`).  When it doesn't, `ruff` / `pytest` / `bandit` / `mypy` / `pylint` / `pyright` are skipped.  Language-agnostic tools like `semgrep` still run.
- Default static-analysis commands now exclude those directories explicitly so third-party code is never scanned even in mixed repos.
- `pytest` exit code 5 ("no tests collected") is treated as a pass.

### Prompts stay sane

- `implement()` truncates oversized validation/CI feedback to 24 KiB (head + tail + truncation marker) before building the AI prompt, keeping enough context for humans and models while staying well below shell argv limits.

### Observability

- New `--log-file PATH` flag on `run`, `dispatch`, and `setup-labels`; also `$AIORCHESTRA_LOG_FILE`.  Parent directories are auto-created.  Existing `$LOG_FILE` behaviour is preserved.
- Unhandled exceptions in the pipeline's fork-child and claim paths now include the exception type and message alongside the traceback, so the root cause isn't lost in structured logs.

## Test plan

- [x] `pytest` — 271 passed (9 new).
  - `test_has_python_sources_*`
  - `test_validate_skips_python_tools_for_non_python_repo`
  - `test_validate_treats_pytest_no_tests_collected_as_pass`
  - `test_truncate_*`, `test_build_prompt_truncates_error_text`
  - `test_setup_logging_file_handler_cli_arg`
- [x] `ruff check .`
- [ ] Manual: `aiorchestra run --repo ironharvy/flower_shop --log-file .tmp/run.log -vv` runs the codex provider without bandit spam and produces a parseable log file.

Made with [Cursor](https://cursor.com)