### PR TITLE
Fix Ruff formatting drift after PR #63

### DIFF
--- a/aiorchestra/_logging.py
+++ b/aiorchestra/_logging.py
@@ -120,9 +120,7 @@ def setup_logging(
     root.addHandler(stderr_handler)
 
     resolved_log_file = (
-        log_file
-        or os.environ.get("AIORCHESTRA_LOG_FILE", "")
-        or os.environ.get("LOG_FILE", "")
+        log_file or os.environ.get("AIORCHESTRA_LOG_FILE", "") or os.environ.get("LOG_FILE", "")
     )
     if resolved_log_file:
         try:

--- a/aiorchestra/cli.py
+++ b/aiorchestra/cli.py
@@ -88,10 +88,7 @@ def build_parser() -> argparse.ArgumentParser:
     run.add_argument(
         "--log-file",
         default=None,
-        help=(
-            "Write logs to this file in addition to stderr. "
-            "Overrides $AIORCHESTRA_LOG_FILE."
-        ),
+        help=("Write logs to this file in addition to stderr. Overrides $AIORCHESTRA_LOG_FILE."),
     )
     run.add_argument(
         "--watch", action="store_true", help="Run continuously, polling for new issues"
@@ -129,10 +126,7 @@ def build_parser() -> argparse.ArgumentParser:
     dispatch.add_argument(
         "--log-file",
         default=None,
-        help=(
-            "Write logs to this file in addition to stderr. "
-            "Overrides $AIORCHESTRA_LOG_FILE."
-        ),
+        help=("Write logs to this file in addition to stderr. Overrides $AIORCHESTRA_LOG_FILE."),
     )
     dispatch.add_argument(
         "--watch", action="store_true", help="Run continuously, polling for new issues"
@@ -164,10 +158,7 @@ def build_parser() -> argparse.ArgumentParser:
     setup.add_argument(
         "--log-file",
         default=None,
-        help=(
-            "Write logs to this file in addition to stderr. "
-            "Overrides $AIORCHESTRA_LOG_FILE."
-        ),
+        help=("Write logs to this file in addition to stderr. Overrides $AIORCHESTRA_LOG_FILE."),
     )
 
     return parser

--- a/aiorchestra/stages/discover.py
+++ b/aiorchestra/stages/discover.py
@@ -91,9 +91,7 @@ def discover_issues(
     if required_label is None:
         eligible_issues = issues
     else:
-        eligible_issues = [
-            issue for issue in issues if required_label in issue.get("labels", [])
-        ]
+        eligible_issues = [issue for issue in issues if required_label in issue.get("labels", [])]
         if not eligible_issues:
             log.error("No issues matched required agent label: %s", required_label)
             return []

--- a/aiorchestra/stages/validate.py
+++ b/aiorchestra/stages/validate.py
@@ -116,9 +116,7 @@ def validate(config: PipelineConfig, repo_root: str | None = None) -> FeedbackRe
                 log.info("pytest collected no tests — treating as pass")
 
     # T1: Static analysis (semgrep, bandit, etc.)
-    errors.extend(
-        _run_static_analysis(review_cfg, repo_root, python_project=python_project)
-    )
+    errors.extend(_run_static_analysis(review_cfg, repo_root, python_project=python_project))
 
     log.info("[validate] completed in %.1fs (%s)", timer.total, timer.summary())
 

--- a/tests/test_validate.py
+++ b/tests/test_validate.py
@@ -228,9 +228,7 @@ def test_validate_treats_pytest_no_tests_collected_as_pass(monkeypatch, tmp_path
     def fake_run(cmd, *, cwd=None, check=False, shell=None, logger=None):
         cmd_str = cmd if isinstance(cmd, str) else " ".join(cmd)
         if cmd_str.startswith("pytest"):
-            return types.SimpleNamespace(
-                returncode=5, stdout="no tests ran", stderr=""
-            )
+            return types.SimpleNamespace(returncode=5, stdout="no tests ran", stderr="")
         return types.SimpleNamespace(returncode=0, stdout="", stderr="")
 
     monkeypatch.setattr(val_mod, "run_command", fake_run)


### PR DESCRIPTION
## Summary
- apply the Ruff formatter output for the five files touched by PR #63
- fix the post-merge `ruff format --check` failure without changing behavior
- keep the follow-up scoped to CI repair only

## Test plan
- [x] `./.venv/bin/python -m ruff format --check aiorchestra/_logging.py aiorchestra/cli.py aiorchestra/stages/discover.py aiorchestra/stages/validate.py tests/test_validate.py`
- [x] `./.venv/bin/python -m pytest -q`

Made with [Cursor](https://cursor.com)