### PR TITLE
Fix CI stage infinite polling on repos with no CI checks

### DIFF
--- a/aiorchestra.yaml.example
+++ b/aiorchestra.yaml.example
@@ -35,6 +35,7 @@ ci:
   enabled: true
   timeout: 600
   poll_interval: 30
+  no_checks_grace: 120  # seconds to wait before treating "no CI checks" as a pass
 
 # Sentry error tracking (optional — requires `pip install aiorchestra[sentry]`).
 # The DSN can also be set via the SENTRY_DSN environment variable.

--- a/aiorchestra/config.py
+++ b/aiorchestra/config.py
@@ -67,6 +67,7 @@ DEFAULTS = {
         "enabled": True,
         "timeout": 600,
         "poll_interval": 30,
+        "no_checks_grace": 120,
     },
     "osint": {
         "enabled": False,

--- a/aiorchestra/stages/ci.py
+++ b/aiorchestra/stages/ci.py
@@ -65,7 +65,9 @@ def wait_for_ci(pr_url: str, config: PipelineConfig) -> FeedbackResult:
                 )
                 return True, None
             log.debug(
-                "No CI checks yet (%.0fs / %ds grace)", waited, no_checks_grace,
+                "No CI checks yet (%.0fs / %ds grace)",
+                waited,
+                no_checks_grace,
             )
             time.sleep(poll_interval)
             continue

--- a/aiorchestra/stages/ci.py
+++ b/aiorchestra/stages/ci.py
@@ -12,14 +12,21 @@ log = logging.getLogger(__name__)
 _CI_FIELDS = "name,state,bucket,link,workflow"
 
 
+def _is_no_checks_error(stderr: str) -> bool:
+    """Return True if the gh CLI error indicates no checks exist on the branch."""
+    return "no checks reported" in stderr.lower()
+
+
 def wait_for_ci(pr_url: str, config: PipelineConfig) -> FeedbackResult:
     """Poll CI status until completion. Returns (success, failure_output)."""
     ci_cfg = config.get("ci", {})
     timeout = ci_cfg.get("timeout", 600)
     poll_interval = ci_cfg.get("poll_interval", 30)
+    no_checks_grace = ci_cfg.get("no_checks_grace", 120)
 
     ci_start = time.monotonic()
     deadline = ci_start + timeout
+    no_checks_since: float | None = None
     poll_count = 0
     log.info("Waiting for CI (timeout=%ds)...", timeout)
 
@@ -29,16 +36,41 @@ def wait_for_ci(pr_url: str, config: PipelineConfig) -> FeedbackResult:
             logger=log,
         )
         poll_count += 1
+
+        no_checks = False
         if result.returncode != 0:
-            log.warning("Failed to check CI status: %s", result.stderr.strip())
+            if _is_no_checks_error(result.stderr):
+                no_checks = True
+            else:
+                log.warning("Failed to check CI status: %s", result.stderr.strip())
+                no_checks_since = None
+                time.sleep(poll_interval)
+                continue
+        else:
+            checks = json.loads(result.stdout)
+            if not checks:
+                no_checks = True
+
+        if no_checks:
+            now = time.monotonic()
+            if no_checks_since is None:
+                no_checks_since = now
+            waited = now - no_checks_since
+            if waited >= no_checks_grace:
+                elapsed = now - ci_start
+                log.info("[ci] completed in %.1fs (%d polls)", elapsed, poll_count)
+                log.info(
+                    "No CI checks found after %ds grace period — skipping CI.",
+                    no_checks_grace,
+                )
+                return True, None
+            log.debug(
+                "No CI checks yet (%.0fs / %ds grace)", waited, no_checks_grace,
+            )
             time.sleep(poll_interval)
             continue
 
-        checks = json.loads(result.stdout)
-
-        if not checks:
-            time.sleep(poll_interval)
-            continue
+        no_checks_since = None
 
         all_done = all(c.get("bucket") != "pending" for c in checks)
         if not all_done:

--- a/tests/test_ci.py
+++ b/tests/test_ci.py
@@ -1,0 +1,170 @@
+"""Tests for aiorchestra.stages.ci — CI polling logic."""
+
+import json
+import types
+
+from aiorchestra.stages import ci as ci_mod
+from aiorchestra.stages.ci import _is_no_checks_error, wait_for_ci
+
+
+def _make_result(returncode=0, stdout="", stderr=""):
+    return types.SimpleNamespace(returncode=returncode, stdout=stdout, stderr=stderr)
+
+
+class TestIsNoChecksError:
+    def test_matches_gh_cli_message(self):
+        assert _is_no_checks_error("no checks reported on the 'main' branch")
+
+    def test_case_insensitive(self):
+        assert _is_no_checks_error("No Checks Reported on the 'main' branch")
+
+    def test_no_match(self):
+        assert not _is_no_checks_error("HTTP 502: server error")
+
+
+class TestWaitForCiNoChecksGrace:
+    """When a repo has no CI checks, wait_for_ci should pass after the grace period."""
+
+    def test_no_checks_stderr_passes_after_grace(self, monkeypatch):
+        """gh pr checks returns non-zero with 'no checks reported' — should pass."""
+        clock = [0.0]
+
+        def fake_monotonic():
+            return clock[0]
+
+        def fake_sleep(seconds):
+            clock[0] += seconds
+
+        def fake_run(cmd, logger=None):
+            return _make_result(
+                returncode=1,
+                stderr="no checks reported on the 'codex/1' branch",
+            )
+
+        monkeypatch.setattr(ci_mod, "run_command", fake_run)
+        monkeypatch.setattr(ci_mod.time, "monotonic", fake_monotonic)
+        monkeypatch.setattr(ci_mod.time, "sleep", fake_sleep)
+
+        ok, output = wait_for_ci(
+            "https://pr/1",
+            {"ci": {"timeout": 600, "poll_interval": 10, "no_checks_grace": 30}},
+        )
+        assert ok is True
+        assert output is None
+
+    def test_no_checks_empty_json_passes_after_grace(self, monkeypatch):
+        """gh pr checks returns 0 with empty array — should pass."""
+        clock = [0.0]
+
+        def fake_monotonic():
+            return clock[0]
+
+        def fake_sleep(seconds):
+            clock[0] += seconds
+
+        def fake_run(cmd, logger=None):
+            return _make_result(returncode=0, stdout="[]")
+
+        monkeypatch.setattr(ci_mod, "run_command", fake_run)
+        monkeypatch.setattr(ci_mod.time, "monotonic", fake_monotonic)
+        monkeypatch.setattr(ci_mod.time, "sleep", fake_sleep)
+
+        ok, output = wait_for_ci(
+            "https://pr/1",
+            {"ci": {"timeout": 600, "poll_interval": 10, "no_checks_grace": 25}},
+        )
+        assert ok is True
+        assert output is None
+
+    def test_no_checks_grace_resets_when_real_error(self, monkeypatch):
+        """A non-'no checks' error should reset the grace timer."""
+        clock = [0.0]
+        call_count = [0]
+
+        def fake_monotonic():
+            return clock[0]
+
+        def fake_sleep(seconds):
+            clock[0] += seconds
+
+        def fake_run(cmd, logger=None):
+            call_count[0] += 1
+            if call_count[0] <= 2:
+                return _make_result(
+                    returncode=1,
+                    stderr="no checks reported on the 'main' branch",
+                )
+            if call_count[0] == 3:
+                return _make_result(returncode=1, stderr="HTTP 502: server error")
+            return _make_result(
+                returncode=1,
+                stderr="no checks reported on the 'main' branch",
+            )
+
+        monkeypatch.setattr(ci_mod, "run_command", fake_run)
+        monkeypatch.setattr(ci_mod.time, "monotonic", fake_monotonic)
+        monkeypatch.setattr(ci_mod.time, "sleep", fake_sleep)
+
+        ok, output = wait_for_ci(
+            "https://pr/1",
+            {"ci": {"timeout": 600, "poll_interval": 10, "no_checks_grace": 25}},
+        )
+        assert ok is True
+        assert output is None
+        # Should take longer because the HTTP error resets the grace timer
+        assert call_count[0] > 3
+
+    def test_checks_appear_after_grace_wait(self, monkeypatch):
+        """If checks appear during the grace period, normal logic takes over."""
+        clock = [0.0]
+        call_count = [0]
+
+        def fake_monotonic():
+            return clock[0]
+
+        def fake_sleep(seconds):
+            clock[0] += seconds
+
+        def fake_run(cmd, logger=None):
+            call_count[0] += 1
+            if call_count[0] <= 2:
+                return _make_result(
+                    returncode=1,
+                    stderr="no checks reported on the 'main' branch",
+                )
+            checks = [{"name": "test", "bucket": "pass", "state": "SUCCESS"}]
+            return _make_result(returncode=0, stdout=json.dumps(checks))
+
+        monkeypatch.setattr(ci_mod, "run_command", fake_run)
+        monkeypatch.setattr(ci_mod.time, "monotonic", fake_monotonic)
+        monkeypatch.setattr(ci_mod.time, "sleep", fake_sleep)
+
+        ok, output = wait_for_ci(
+            "https://pr/1",
+            {"ci": {"timeout": 600, "poll_interval": 10, "no_checks_grace": 120}},
+        )
+        assert ok is True
+        assert output is None
+
+    def test_default_grace_period_is_120(self, monkeypatch):
+        """Without explicit config, grace period defaults to 120s."""
+        clock = [0.0]
+
+        def fake_monotonic():
+            return clock[0]
+
+        def fake_sleep(seconds):
+            clock[0] += seconds
+
+        def fake_run(cmd, logger=None):
+            return _make_result(returncode=0, stdout="[]")
+
+        monkeypatch.setattr(ci_mod, "run_command", fake_run)
+        monkeypatch.setattr(ci_mod.time, "monotonic", fake_monotonic)
+        monkeypatch.setattr(ci_mod.time, "sleep", fake_sleep)
+
+        ok, _ = wait_for_ci("https://pr/1", {"ci": {"timeout": 600, "poll_interval": 30}})
+        assert ok is True
+        # With 30s poll interval and 120s grace, should take ~4 polls (120/30)
+        assert clock[0] >= 120
+        assert clock[0] < 180


### PR DESCRIPTION
When a repository has no CI checks configured (e.g. no GitHub Actions
workflows), `gh pr checks` returns "no checks reported" and the CI
stage would poll indefinitely until the 600s timeout. This adds a
`no_checks_grace` period (default 120s) after which the stage treats
the absence of checks as a pass rather than waiting forever.

https://claude.ai/code/session_01ARFhhSAzrB723CopbfSHbg