### PR TITLE
Use filtered staging for agent commits

### DIFF
--- a/aiorchestra/pipeline.py
+++ b/aiorchestra/pipeline.py
@@ -23,7 +23,8 @@ from aiorchestra.ai import (
 )
 from aiorchestra.ai._agents import KNOWN_AGENTS
 from aiorchestra.config import _deep_merge, load_config
-from aiorchestra.stages._shell import StageTimer, has_diff_from_main, run_command
+from aiorchestra.stages._shell import StageTimer, has_diff_from_main
+from aiorchestra.stages._workspace_artifacts import GitStatusError, has_publishable_changes
 from aiorchestra.stages.clarification import request_clarification
 from aiorchestra.stages.discover import discover_issues
 from aiorchestra.stages.osint import enrich_issue
@@ -60,13 +61,21 @@ def _fmt_duration(seconds: float) -> str:
 
 
 def _has_changes(repo_root: str) -> bool:
-    """Return True if the worktree has any uncommitted or staged changes."""
-    result = run_command(
-        ["git", "status", "--porcelain"],
-        cwd=repo_root,
-        logger=log,
-    )
-    return bool(result.stdout.strip())
+    """Return True if the worktree has publishable uncommitted or staged changes."""
+    try:
+        return has_publishable_changes(repo_root)
+    except GitStatusError as exc:
+        log.error("%s", exc)
+        return False
+
+
+def _has_preexisting_publishable_changes(repo_root: str) -> bool:
+    """Return True when an agent loop would start from a dirty publishable baseline."""
+    try:
+        return has_publishable_changes(repo_root)
+    except GitStatusError as exc:
+        log.error("%s", exc)
+        return True
 
 
 def _branch_has_existing_work(repo_root: str) -> bool:
@@ -572,6 +581,10 @@ class Pipeline:
         attempt_label: str = "Implementation",
     ) -> bool | str:
         """Returns True on success, False on failure, or _DEFERRED."""
+        if _has_preexisting_publishable_changes(ctx.repo_root):
+            log.error("Working tree has pre-existing publishable changes — aborting before agent")
+            return False
+
         validation_errors = error_text
         current_prompt = prompt_name
 

--- a/aiorchestra/stages/_workspace_artifacts.py
+++ b/aiorchestra/stages/_workspace_artifacts.py
@@ -1,15 +1,16 @@
 """Workspace paths that the orchestrator creates and must not land in agent commits.
 
-Local `.git/info/exclude` keeps them untracked. If they were ever staged or
-tracked, `untrack_artifact_paths` removes them from the index before publish.
+Local `.git/info/exclude` keeps untracked copies out of status. Publish uses
+filtered path staging so the orchestrator does not forcibly remove target-repo
+paths that happen to match common artifact names.
 """
 
 from __future__ import annotations
 
 import logging
-from pathlib import Path
+from pathlib import Path, PurePosixPath
 
-from aiorchestra.stages._shell import run_command
+from aiorchestra.stages._shell import CommandError, run_command, run_command_or_fail
 
 log = logging.getLogger(__name__)
 
@@ -25,16 +26,12 @@ LOCAL_GIT_EXCLUDE_PATTERNS = (
     "node_modules/",
 )
 
-# Top-level (or well-known) paths passed to `git rm -r --cached` — no trailing slash
-_GIT_RM_TOP_LEVEL = (
-    ".venv",
-    "venv",
-    "node_modules",
-    ".pytest_cache",
-    ".mypy_cache",
-    ".ruff_cache",
-    ".tox",
+_ARTIFACT_DIR_NAMES = frozenset(
+    pattern.rstrip("/") for pattern in LOCAL_GIT_EXCLUDE_PATTERNS
 )
+
+class GitStatusError(RuntimeError):
+    """Raised when git status/add cannot be inspected safely."""
 
 
 def ensure_local_git_excludes(repo_dir: Path) -> None:
@@ -61,47 +58,92 @@ def ensure_local_git_excludes(repo_dir: Path) -> None:
     log.info("Added %d local git exclude patterns in %s", len(missing), exclude_file)
 
 
-def _pycache_dirs_in_index(repo_root: str) -> set[str]:
-    result = run_command(
-        ["git", "ls-files"],
-        cwd=repo_root,
-        logger=log,
-    )
-    if result.returncode != 0 or not result.stdout.strip():
-        return set()
-    dirs: set[str] = set()
-    for path in result.stdout.splitlines():
-        if "__pycache__" not in path:
-            continue
-        parts = path.split("/")
-        for i, segment in enumerate(parts):
-            if segment == "__pycache__":
-                dirs.add("/".join(parts[: i + 1]))
-    return dirs
+def _status_paths_from_porcelain_z(output: str) -> list[str]:
+    """Return all paths mentioned by `git status --porcelain -z`.
 
-
-def _untrack_pycache_paths(repo_root: str) -> None:
-    for d in sorted(_pycache_dirs_in_index(repo_root)):
-        run_command(
-            ["git", "rm", "-r", "--cached", "--ignore-unmatch", "--", d],
-            cwd=repo_root,
-            check=False,
-            logger=log,
-        )
-
-
-def untrack_artifact_paths_from_index(repo_root: str) -> None:
-    """Remove orchestration artifacts from the git index; leaves working tree on disk.
-
-    Call this before `git add -A` so venv, caches, and `__pycache__` never
-    become part of the commit. Untracked copies stay ignored via
-    :func:`ensure_local_git_excludes`.
+    Rename/copy records contain two NUL-delimited paths. We keep both so
+    `git add -A -- <paths>` can stage the old deletion and the new path.
     """
-    for name in _GIT_RM_TOP_LEVEL:
-        run_command(
-            ["git", "rm", "-r", "--cached", "--ignore-unmatch", "--", name],
+    entries = output.split("\0")
+    paths: list[str] = []
+    i = 0
+    while i < len(entries):
+        entry = entries[i]
+        i += 1
+        if not entry:
+            continue
+        if len(entry) < 4:
+            continue
+
+        status = entry[:2]
+        path = entry[3:]
+        if path:
+            paths.append(path)
+
+        if status[0] in {"R", "C"} or status[1] in {"R", "C"}:
+            if i < len(entries) and entries[i]:
+                paths.append(entries[i])
+            i += 1
+
+    return paths
+
+
+def is_workspace_artifact_path(path: str) -> bool:
+    """Return True when *path* lives under an orchestrator-created artifact dir."""
+    return any(part in _ARTIFACT_DIR_NAMES for part in PurePosixPath(path).parts)
+
+
+def publishable_status_paths(repo_root: str) -> list[str]:
+    """Return dirty worktree paths that are safe to include in an agent commit."""
+    try:
+        result = run_command_or_fail(
+            ["git", "status", "--porcelain", "-z", "--untracked-files=all"],
+            error_msg="Failed to inspect git status",
             cwd=repo_root,
-            check=False,
             logger=log,
         )
-    _untrack_pycache_paths(repo_root)
+    except CommandError as exc:
+        raise GitStatusError(str(exc)) from exc
+
+    paths = _status_paths_from_porcelain_z(result.stdout)
+    publishable = [path for path in paths if not is_workspace_artifact_path(path)]
+    return list(dict.fromkeys(publishable))
+
+
+def has_publishable_changes(repo_root: str) -> bool:
+    """Return True if the worktree has non-artifact changes."""
+    return bool(publishable_status_paths(repo_root))
+
+
+def stage_publishable_changes(repo_root: str) -> list[str]:
+    """Stage only non-artifact dirty paths.
+
+    Returns the paths that have staged changes after filtering.
+    """
+    paths = publishable_status_paths(repo_root)
+    if not paths:
+        log.debug("No publishable local changes to stage.")
+        return []
+
+    try:
+        run_command_or_fail(
+            ["git", "add", "-A", "--", *paths],
+            error_msg="git add failed",
+            cwd=repo_root,
+            logger=log,
+        )
+        diff = run_command(
+            ["git", "diff", "--cached", "--quiet", "--", *paths],
+            cwd=repo_root,
+            logger=log,
+        )
+    except CommandError as exc:
+        raise GitStatusError(str(exc)) from exc
+
+    if diff.returncode not in {0, 1}:
+        detail = diff.stderr.strip() or diff.stdout.strip() or "git diff failed"
+        raise GitStatusError(f"Failed to inspect staged diff: {detail}")
+
+    if diff.returncode == 0:
+        return []
+    return paths

--- a/aiorchestra/stages/_workspace_artifacts.py
+++ b/aiorchestra/stages/_workspace_artifacts.py
@@ -26,9 +26,8 @@ LOCAL_GIT_EXCLUDE_PATTERNS = (
     "node_modules/",
 )
 
-_ARTIFACT_DIR_NAMES = frozenset(
-    pattern.rstrip("/") for pattern in LOCAL_GIT_EXCLUDE_PATTERNS
-)
+_ARTIFACT_DIR_NAMES = frozenset(pattern.rstrip("/") for pattern in LOCAL_GIT_EXCLUDE_PATTERNS)
+
 
 class GitStatusError(RuntimeError):
     """Raised when git status/add cannot be inspected safely."""

--- a/aiorchestra/stages/publish.py
+++ b/aiorchestra/stages/publish.py
@@ -11,8 +11,9 @@ from aiorchestra.stages._shell import (
     run_command_or_fail,
 )
 from aiorchestra.stages._workspace_artifacts import (
+    GitStatusError,
     ensure_local_git_excludes,
-    untrack_artifact_paths_from_index,
+    stage_publishable_changes,
 )
 from aiorchestra.stages.types import IssueData, PublishResult
 
@@ -80,28 +81,27 @@ def _commit_changes(issue: IssueData, repo_root: str) -> bool | None:
     commit, or None on a git error (caller should abort).
     """
     try:
-        result = run_command_or_fail(
-            ["git", "status", "--porcelain"],
-            error_msg="Failed to inspect git status",
-            cwd=repo_root,
-            logger=log,
-        )
-    except CommandError:
+        ensure_local_git_excludes(Path(repo_root))
+        staged_paths = stage_publishable_changes(repo_root)
+    except GitStatusError as exc:
+        log.error("%s", exc)
         return None
 
-    if not result.stdout.strip():
-        log.debug("No local changes to commit.")
+    if not staged_paths:
+        log.debug("No publishable local changes to commit.")
         return False
 
     log.info("Committing local changes for issue #%d", issue["number"])
     try:
-        ensure_local_git_excludes(Path(repo_root))
-        untrack_artifact_paths_from_index(repo_root)
         run_command_or_fail(
-            ["git", "add", "-A"], error_msg="git add failed", cwd=repo_root, logger=log
-        )
-        run_command_or_fail(
-            ["git", "commit", "-m", f"Fix #{issue['number']}: {issue['title']}"],
+            [
+                "git",
+                "commit",
+                "-m",
+                f"Fix #{issue['number']}: {issue['title']}",
+                "--",
+                *staged_paths,
+            ],
             error_msg="git commit failed",
             cwd=repo_root,
             logger=log,

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -15,6 +15,15 @@ def _mock_ensure_labels(monkeypatch):
 
 
 @pytest.fixture(autouse=True)
+def _mock_clean_agent_loop_baseline(monkeypatch):
+    """Most pipeline unit tests use plain temp dirs, not real git repos."""
+    monkeypatch.setattr(
+        "aiorchestra.pipeline._has_preexisting_publishable_changes",
+        lambda repo_root: False,
+    )
+
+
+@pytest.fixture(autouse=True)
 def _reset_sentry():
     """Ensure Sentry module state doesn't leak between tests."""
     import aiorchestra._sentry as _s

--- a/tests/test_pipeline.py
+++ b/tests/test_pipeline.py
@@ -167,6 +167,80 @@ def test_validation_retry_uses_fix_validation_prompt(monkeypatch, tmp_path):
     ]
 
 
+def test_validation_loop_checks_baseline_once_per_loop(monkeypatch, tmp_path):
+    baseline_checks = []
+    validate_results = iter([(False, "lint broke"), (True, None)])
+
+    monkeypatch.setattr(
+        "aiorchestra.pipeline.prepare_environment",
+        lambda repo, branch, workspace: str(tmp_path),
+    )
+    monkeypatch.setattr(
+        "aiorchestra.pipeline.load_config",
+        lambda path, repo_root=None: {
+            "ai": {"max_retries": 2},
+            "ci": {"enabled": False},
+            "review": {"enabled": False},
+        },
+    )
+    monkeypatch.setattr("aiorchestra.pipeline._has_changes", lambda repo_root: True)
+    monkeypatch.setattr("aiorchestra.pipeline.enrich_issue", lambda issue, config: "")
+    monkeypatch.setattr(
+        "aiorchestra.pipeline._has_preexisting_publishable_changes",
+        lambda repo_root: bool(baseline_checks.append(repo_root)) and False,
+    )
+    monkeypatch.setattr(
+        "aiorchestra.pipeline.implement",
+        lambda issue, config, prompt_name="implement", error_text=None, repo_root=None, osint_context="", repo=None: (
+            InvokeResult(success=True)
+        ),
+    )
+    monkeypatch.setattr(
+        "aiorchestra.pipeline.validate",
+        lambda config, repo_root=None: next(validate_results),
+    )
+    monkeypatch.setattr(
+        "aiorchestra.pipeline.publish",
+        lambda repo, branch, issue, repo_root, pr_url=None: "https://example.test/pr/1",
+    )
+
+    pipeline = Pipeline(repo="owner/repo", label="claude", config={})
+
+    assert pipeline._process_issue({"number": 8, "title": "Check baseline"}) is True
+    assert baseline_checks == [str(tmp_path)]
+
+
+def test_dirty_agent_loop_baseline_aborts_before_implement(monkeypatch, tmp_path):
+    calls = []
+
+    monkeypatch.setattr(
+        "aiorchestra.pipeline.prepare_environment",
+        lambda repo, branch, workspace: str(tmp_path),
+    )
+    monkeypatch.setattr(
+        "aiorchestra.pipeline.load_config",
+        lambda path, repo_root=None: {
+            "ai": {"max_retries": 1},
+            "ci": {"enabled": False},
+            "review": {"enabled": False},
+        },
+    )
+    monkeypatch.setattr("aiorchestra.pipeline.enrich_issue", lambda issue, config: "")
+    monkeypatch.setattr(
+        "aiorchestra.pipeline._has_preexisting_publishable_changes",
+        lambda repo_root: True,
+    )
+    monkeypatch.setattr(
+        "aiorchestra.pipeline.implement",
+        lambda *args, **kwargs: calls.append(("implement",)) or InvokeResult(success=True),
+    )
+
+    pipeline = Pipeline(repo="owner/repo", label="claude", config={})
+
+    assert pipeline._process_issue({"number": 12, "title": "Dirty baseline"}) is False
+    assert calls == []
+
+
 def test_ci_fix_revalidates_and_republishes(monkeypatch, tmp_path):
     calls: list[tuple] = []
     validate_results = iter([(True, None), (True, None)])
@@ -322,6 +396,8 @@ def test_publish_refuses_empty_branch(monkeypatch, tmp_path):
         return types.SimpleNamespace(returncode=0, stdout="", stderr="")
 
     monkeypatch.setattr(pub_mod, "run_command", fake_run)
+    monkeypatch.setattr(pub_mod, "ensure_local_git_excludes", lambda repo_root: None)
+    monkeypatch.setattr(pub_mod, "stage_publishable_changes", lambda repo_root: [])
 
     from aiorchestra.stages.publish import publish
 
@@ -355,6 +431,12 @@ def test_publish_aborts_on_git_error(monkeypatch, tmp_path):
         return types.SimpleNamespace(returncode=0, stdout="", stderr="")
 
     monkeypatch.setattr(pub_mod, "run_command", fake_run)
+    monkeypatch.setattr(pub_mod, "ensure_local_git_excludes", lambda repo_root: None)
+    monkeypatch.setattr(
+        pub_mod,
+        "stage_publishable_changes",
+        lambda repo_root: (_ for _ in ()).throw(pub_mod.GitStatusError("fatal: not a git repo")),
+    )
 
     from aiorchestra.stages.publish import publish
 

--- a/tests/test_publish.py
+++ b/tests/test_publish.py
@@ -297,9 +297,7 @@ def test_commit_changes_commits_only_publishable_paths(tmp_path: Path):
     committed_paths = _run_git(repo, "show", "--name-only", "--format=", "HEAD").stdout.splitlines()
     assert committed_paths == ["real.txt"]
     assert ".venv/lib/site/pkg.py" in _run_git(repo, "ls-files").stdout.splitlines()
-    assert _run_git(repo, "diff", "--name-only").stdout.splitlines() == [
-        ".venv/lib/site/pkg.py"
-    ]
+    assert _run_git(repo, "diff", "--name-only").stdout.splitlines() == [".venv/lib/site/pkg.py"]
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_publish.py
+++ b/tests/test_publish.py
@@ -2,9 +2,16 @@
 
 import subprocess
 import types
+from pathlib import Path
 
 from aiorchestra.stages import publish as pub_mod
-from aiorchestra.stages.publish import _build_pr_body, _create_pr, _find_existing_pr, publish
+from aiorchestra.stages.publish import (
+    _build_pr_body,
+    _commit_changes,
+    _create_pr,
+    _find_existing_pr,
+    publish,
+)
 
 ISSUE = {"number": 24, "title": "Add multi-level verbose logging"}
 ISSUE_RICH = {
@@ -20,6 +27,22 @@ REPO_ROOT = "/tmp/fake-repo"
 
 def _make_result(returncode=0, stdout="", stderr=""):
     return types.SimpleNamespace(returncode=returncode, stdout=stdout, stderr=stderr)
+
+
+def _run_git(tmp: Path, *args: str) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(
+        ["git", *args],
+        cwd=tmp,
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+
+
+def _init_repo(tmp: Path) -> None:
+    _run_git(tmp, "init", "-b", "main")
+    _run_git(tmp, "config", "user.email", "test@test.local")
+    _run_git(tmp, "config", "user.name", "AIOrchestra Test")
 
 
 # ---------------------------------------------------------------------------
@@ -255,6 +278,30 @@ def test_create_pr_does_not_retry_body_too_long(monkeypatch):
     assert len(calls) == 1
 
 
+def test_commit_changes_commits_only_publishable_paths(tmp_path: Path):
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    _init_repo(repo)
+    (repo / "real.txt").write_text("ok\n")
+    artifact = repo / ".venv" / "lib" / "site" / "pkg.py"
+    artifact.parent.mkdir(parents=True)
+    artifact.write_text("tracked artifact\n")
+    _run_git(repo, "add", "-A")
+    _run_git(repo, "commit", "-m", "initial")
+
+    (repo / "real.txt").write_text("changed\n")
+    artifact.write_text("modified artifact\n")
+
+    assert _commit_changes(ISSUE, str(repo)) is True
+
+    committed_paths = _run_git(repo, "show", "--name-only", "--format=", "HEAD").stdout.splitlines()
+    assert committed_paths == ["real.txt"]
+    assert ".venv/lib/site/pkg.py" in _run_git(repo, "ls-files").stdout.splitlines()
+    assert _run_git(repo, "diff", "--name-only").stdout.splitlines() == [
+        ".venv/lib/site/pkg.py"
+    ]
+
+
 # ---------------------------------------------------------------------------
 # publish — end-to-end with existing PR
 # ---------------------------------------------------------------------------
@@ -280,6 +327,8 @@ def test_publish_with_existing_pr_url_skips_creation(monkeypatch):
 
     monkeypatch.setattr(pub_mod, "run_command", fake_run_command)
     monkeypatch.setattr("aiorchestra.stages._shell.run_command", fake_run_command)
+    monkeypatch.setattr(pub_mod, "ensure_local_git_excludes", lambda repo_root: None)
+    monkeypatch.setattr(pub_mod, "stage_publishable_changes", lambda repo_root: ["file.py"])
 
     result = publish(REPO, BRANCH, ISSUE, REPO_ROOT, pr_url="https://github.com/owner/repo/pull/25")
     assert result == "https://github.com/owner/repo/pull/25"
@@ -308,6 +357,8 @@ def test_publish_without_pr_url_detects_existing(monkeypatch):
 
     monkeypatch.setattr(pub_mod, "run_command", fake_run_command)
     monkeypatch.setattr("aiorchestra.stages._shell.run_command", fake_run_command)
+    monkeypatch.setattr(pub_mod, "ensure_local_git_excludes", lambda repo_root: None)
+    monkeypatch.setattr(pub_mod, "stage_publishable_changes", lambda repo_root: ["file.py"])
 
     result = publish(REPO, BRANCH, ISSUE, REPO_ROOT)
     assert result == existing_url

--- a/tests/test_workspace_artifacts.py
+++ b/tests/test_workspace_artifacts.py
@@ -3,7 +3,11 @@
 import subprocess
 from pathlib import Path
 
-from aiorchestra.stages._workspace_artifacts import untrack_artifact_paths_from_index
+from aiorchestra.stages._workspace_artifacts import (
+    is_workspace_artifact_path,
+    publishable_status_paths,
+    stage_publishable_changes,
+)
 
 
 def _init_repo(tmp: Path) -> None:
@@ -22,57 +26,114 @@ def _init_repo(tmp: Path) -> None:
     )
 
 
-def _ls_files(tmp: Path) -> str:
-    r = subprocess.run(
-        ["git", "ls-files"],
+def _run_git(tmp: Path, *args: str) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(
+        ["git", *args],
         cwd=tmp,
         check=True,
         capture_output=True,
         text=True,
     )
-    return r.stdout
 
 
-def test_untrack_artifact_paths_removes_venv_from_index(tmp_path: Path) -> None:
-    """Orchestrator .venv should not stay in the index after untrack."""
+def _commit_all(tmp: Path, message: str = "commit") -> None:
+    _run_git(tmp, "add", "-A")
+    _run_git(tmp, "commit", "-m", message)
+
+
+def _ls_files(tmp: Path) -> str:
+    return _run_git(tmp, "ls-files").stdout
+
+
+def _cached_names(tmp: Path) -> list[str]:
+    output = _run_git(tmp, "diff", "--cached", "--name-only").stdout
+    return [line for line in output.splitlines() if line]
+
+
+def test_workspace_artifact_path_filter_matches_nested_artifacts() -> None:
+    assert is_workspace_artifact_path(".venv/lib/site.py")
+    assert is_workspace_artifact_path("packages/web/node_modules/pkg/index.js")
+    assert is_workspace_artifact_path("src/app/__pycache__/x.cpython-312.pyc")
+    assert not is_workspace_artifact_path("src/app.py")
+
+
+def test_stage_publishable_changes_filters_artifacts(tmp_path: Path) -> None:
+    """Only source changes should be staged; artifact trees stay untouched."""
     repo = tmp_path / "repo"
     repo.mkdir()
     _init_repo(repo)
     (repo / "real.txt").write_text("ok\n")
+    _commit_all(repo)
+
+    (repo / "real.txt").write_text("changed\n")
     vfile = repo / ".venv" / "lib" / "site" / "pkg.py"
-    vfile.parent.mkdir(parents=True)
-    vfile.write_text("# venv file\n")
-    subprocess.run(
-        ["git", "add", "real.txt", str(vfile.relative_to(repo))],
-        cwd=repo,
-        check=True,
-        capture_output=True,
-    )
-    subprocess.run(
-        ["git", "commit", "-m", "track venv and real"], cwd=repo, check=True, capture_output=True
-    )
-    before = [p for p in _ls_files(repo).splitlines() if p]
-    assert any(".venv" in p for p in before), "test setup must include tracked .venv"
+    pycache = repo / "app" / "__pycache__" / "x.cpython-312.pyc"
+    node_module = repo / "packages" / "web" / "node_modules" / "pkg" / "index.js"
+    for path in (vfile, pycache, node_module):
+        path.parent.mkdir(parents=True)
+        path.write_text("artifact\n")
 
-    untrack_artifact_paths_from_index(str(repo))
-    after = [p for p in _ls_files(repo).splitlines() if p]
-    assert "real.txt" in after
-    assert not any(".venv" in p for p in after)
+    staged = stage_publishable_changes(str(repo))
+
+    assert staged == ["real.txt"]
+    assert _cached_names(repo) == ["real.txt"]
 
 
-def test_untrack_artifact_paths_removes_nested_pycache_from_index(tmp_path: Path) -> None:
-    """__pycache__ trees tracked by mistake are dropped from the index."""
+def test_stage_publishable_changes_stages_deletions(tmp_path: Path) -> None:
     repo = tmp_path / "repo"
     repo.mkdir()
     _init_repo(repo)
-    pyc = repo / "app" / "__pycache__" / "x.cpython-312.pyc"
-    pyc.parent.mkdir(parents=True)
-    pyc.write_bytes(b"\x00")
-    subprocess.run(["git", "add", "app/"], cwd=repo, check=True, capture_output=True)
-    subprocess.run(["git", "commit", "-m", "pycache"], cwd=repo, check=True, capture_output=True)
-    before = [p for p in _ls_files(repo).splitlines() if p]
-    assert any("__pycache__" in p for p in before), "test setup must track __pycache__"
+    deleted = repo / "old.txt"
+    deleted.write_text("old\n")
+    _commit_all(repo)
 
-    untrack_artifact_paths_from_index(str(repo))
-    after = [p for p in _ls_files(repo).splitlines() if p]
-    assert not any("__pycache__" in p for p in after)
+    deleted.unlink()
+
+    assert stage_publishable_changes(str(repo)) == ["old.txt"]
+    assert _run_git(repo, "diff", "--cached", "--name-status").stdout.startswith("D\told.txt")
+
+
+def test_publishable_status_paths_include_rename_sides(tmp_path: Path) -> None:
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    _init_repo(repo)
+    (repo / "old.txt").write_text("old\n")
+    _commit_all(repo)
+
+    _run_git(repo, "mv", "old.txt", "new.txt")
+
+    assert set(publishable_status_paths(str(repo))) == {"old.txt", "new.txt"}
+
+
+def test_stage_publishable_changes_does_not_untrack_artifacts(tmp_path: Path) -> None:
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    _init_repo(repo)
+    (repo / "real.txt").write_text("ok\n")
+    artifact = repo / ".venv" / "lib" / "site" / "pkg.py"
+    artifact.parent.mkdir(parents=True)
+    artifact.write_text("tracked artifact\n")
+    _commit_all(repo, "track artifact")
+
+    (repo / "real.txt").write_text("changed\n")
+    artifact.write_text("modified artifact\n")
+
+    assert stage_publishable_changes(str(repo)) == ["real.txt"]
+    assert _cached_names(repo) == ["real.txt"]
+    assert ".venv/lib/site/pkg.py" in _ls_files(repo).splitlines()
+
+
+def test_stage_publishable_changes_ignores_artifact_only_changes(tmp_path: Path) -> None:
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    _init_repo(repo)
+    artifact = repo / ".venv" / "lib" / "site" / "pkg.py"
+    artifact.parent.mkdir(parents=True)
+    artifact.write_text("tracked artifact\n")
+    _commit_all(repo, "track artifact")
+
+    artifact.write_text("modified artifact\n")
+
+    assert stage_publishable_changes(str(repo)) == []
+    assert _cached_names(repo) == []
+    assert ".venv/lib/site/pkg.py" in _ls_files(repo).splitlines()


### PR DESCRIPTION
## Summary
- Replace broad `git add -A` plus artifact untracking with filtered staging of publishable paths.
- Add a clean non-artifact baseline check before each agent validation/remediation loop.
- Cover staging filters, tracked artifacts, deletions, renames, and baseline behavior with tests.

## Test plan
- `.venv/bin/python -m pytest`
- `.venv/bin/ruff check aiorchestra/stages/_workspace_artifacts.py aiorchestra/stages/publish.py aiorchestra/pipeline.py tests/conftest.py tests/test_workspace_artifacts.py tests/test_publish.py tests/test_pipeline.py`
- `git diff --check`


Made with [Cursor](https://cursor.com)