### PR TITLE
Fix publish and review retry idempotency

### DIFF
--- a/aiorchestra/pipeline.py
+++ b/aiorchestra/pipeline.py
@@ -702,6 +702,14 @@ class Pipeline:
                 if not pr_url:
                     return None
 
+        log.info("%s final check after remediation", stage_name)
+        ok, feedback = check_fn(pr_url)
+        if ok:
+            return pr_url
+        if feedback:
+            log.info("%s final feedback (first 500 chars): %.500s", stage_name, feedback)
+            log.debug("%s final full feedback: %s", stage_name, feedback)
+
         log.error("%s failed after %d attempts", stage_name, ctx.max_retries)
         return None
 

--- a/aiorchestra/stages/publish.py
+++ b/aiorchestra/stages/publish.py
@@ -24,6 +24,10 @@ _MAX_PR_BODY_CHARS = 60_000
 _PR_CREATE_ATTEMPTS = 2
 _PR_CREATE_RETRY_DELAY_SECONDS = 2.0
 _NON_RETRYABLE_PR_ERRORS = ("body is too long",)
+_DUPLICATE_PR_ERROR_PATTERNS = (
+    "a pull request for branch",
+    "already exists",
+)
 _TRANSIENT_PR_ERROR_PATTERNS = (
     "timeout",
     "timed out",
@@ -130,7 +134,23 @@ def _push_branch(branch: str, repo_root: str) -> bool:
 def _find_existing_pr(repo: str, branch: str, repo_root: str) -> str | None:
     """Return the URL of an open PR for *branch*, or ``None`` if none exists."""
     result = run_command(
-        ["gh", "pr", "view", "--repo", repo, "--head", branch, "--json", "url", "--jq", ".url"],
+        [
+            "gh",
+            "pr",
+            "list",
+            "--repo",
+            repo,
+            "--head",
+            branch,
+            "--state",
+            "open",
+            "--limit",
+            "1",
+            "--json",
+            "url",
+            "--jq",
+            ".[0].url // empty",
+        ],
         cwd=repo_root,
         logger=log,
     )
@@ -185,6 +205,12 @@ def _is_transient_pr_error(detail: str) -> bool:
     if any(pattern in lowered for pattern in _NON_RETRYABLE_PR_ERRORS):
         return False
     return any(pattern in lowered for pattern in _TRANSIENT_PR_ERROR_PATTERNS)
+
+
+def _is_duplicate_pr_error(detail: str) -> bool:
+    """Return True when GitHub reports a PR already exists for this branch."""
+    lowered = detail.lower()
+    return any(pattern in lowered for pattern in _DUPLICATE_PR_ERROR_PATTERNS)
 
 
 def _build_pr_body(issue: IssueData, repo_root: str, repo: str) -> str:
@@ -259,6 +285,13 @@ def _create_pr(repo: str, branch: str, issue: IssueData, repo_root: str) -> Publ
             return pr_url
         except CommandError as exc:
             detail = exc.result.stderr.strip() or exc.result.stdout.strip() or str(exc)
+            if _is_duplicate_pr_error(detail):
+                existing = _find_existing_pr(repo, branch, repo_root)
+                if existing:
+                    log.info("PR already exists after create failure: %s", existing)
+                    return existing
+                return None
+
             if attempt >= _PR_CREATE_ATTEMPTS or not _is_transient_pr_error(detail):
                 return None
 

--- a/tests/test_pipeline.py
+++ b/tests/test_pipeline.py
@@ -763,11 +763,88 @@ def test_review_fix_triggers_ci_recheck(monkeypatch, tmp_path):
     ]
 
 
+def test_review_final_check_after_last_remediation(monkeypatch, tmp_path):
+    """A fix pushed on the last review attempt must be checked before failing."""
+    calls: list[tuple] = []
+    validate_results = iter([(True, None), (True, None)])
+    review_results = iter([(False, "needs polish"), (True, None)])
+
+    monkeypatch.setattr(
+        "aiorchestra.pipeline.prepare_environment",
+        lambda repo, branch, workspace: str(tmp_path),
+    )
+    monkeypatch.setattr(
+        "aiorchestra.pipeline.load_config",
+        lambda path, repo_root=None: {
+            "ai": {"max_retries": 1},
+            "ci": {"enabled": False},
+            "review": {"enabled": True},
+        },
+    )
+    monkeypatch.setattr("aiorchestra.pipeline._has_changes", lambda repo_root: True)
+    monkeypatch.setattr("aiorchestra.pipeline.enrich_issue", lambda issue, config: "")
+
+    def fake_implement(
+        issue,
+        config,
+        prompt_name="implement",
+        error_text=None,
+        repo_root=None,
+        osint_context="",
+        repo=None,
+    ):
+        calls.append(("implement", prompt_name, error_text))
+        return InvokeResult(success=True)
+
+    def fake_validate(config, repo_root=None):
+        calls.append(("validate",))
+        return next(validate_results)
+
+    def fake_publish(repo, branch, issue, repo_root, pr_url=None):
+        calls.append(("publish", pr_url))
+        return pr_url or "https://example.test/pr/1"
+
+    def fake_review(repo, branch, config, issue=None, repo_root=None):
+        calls.append(("review",))
+        return next(review_results)
+
+    monkeypatch.setattr("aiorchestra.pipeline.implement", fake_implement)
+    monkeypatch.setattr("aiorchestra.pipeline.validate", fake_validate)
+    monkeypatch.setattr("aiorchestra.pipeline.publish", fake_publish)
+    monkeypatch.setattr("aiorchestra.pipeline.review", fake_review)
+
+    pipeline = Pipeline(
+        repo="owner/repo",
+        label="claude",
+        config={"ai": {"provider": "claude-code"}},
+    )
+
+    assert pipeline._process_issue({"number": 40, "title": "Review final fix"}) is True
+    assert calls == [
+        ("implement", "implement", None),
+        ("validate",),
+        ("publish", None),
+        ("review",),
+        ("implement", "fix_review", "needs polish"),
+        ("validate",),
+        ("publish", "https://example.test/pr/1"),
+        ("review",),
+    ]
+
+
 def test_review_fix_ci_failure_fails_issue(monkeypatch, tmp_path):
     """If CI fails after review-fix and cannot be remediated, the issue fails."""
     validate_results = iter([(True, None), (True, None), (True, None), (True, None), (True, None)])
     # Initial CI passes, post-review-fix CI always fails.
-    ci_results = iter([(True, None), (False, "ci broke"), (False, "ci broke"), (False, "ci broke")])
+    ci_results = iter(
+        [
+            (True, None),
+            (False, "ci broke"),
+            (False, "ci broke"),
+            (False, "ci broke"),
+            (False, "ci broke"),
+        ]
+    )
     review_results = iter([(False, "fix needed")])
 
     monkeypatch.setattr(

--- a/tests/test_publish.py
+++ b/tests/test_publish.py
@@ -52,13 +52,34 @@ def _init_repo(tmp: Path) -> None:
 
 def test_find_existing_pr_returns_url_when_pr_exists(monkeypatch):
     url = "https://github.com/owner/repo/pull/25"
-    monkeypatch.setattr(
-        pub_mod,
-        "run_command",
-        lambda cmd, cwd=None, logger=None: _make_result(stdout=url + "\n"),
-    )
+    commands_run = []
+
+    def fake_run_command(cmd, cwd=None, logger=None):
+        commands_run.append(cmd)
+        return _make_result(stdout=url + "\n")
+
+    monkeypatch.setattr(pub_mod, "run_command", fake_run_command)
 
     assert _find_existing_pr(REPO, BRANCH, REPO_ROOT) == url
+    assert commands_run == [
+        [
+            "gh",
+            "pr",
+            "list",
+            "--repo",
+            REPO,
+            "--head",
+            BRANCH,
+            "--state",
+            "open",
+            "--limit",
+            "1",
+            "--json",
+            "url",
+            "--jq",
+            ".[0].url // empty",
+        ]
+    ]
 
 
 def test_find_existing_pr_returns_none_when_no_pr(monkeypatch):
@@ -93,8 +114,8 @@ def test_create_pr_returns_existing_pr_url(monkeypatch):
 
     def fake_run_command(cmd, cwd=None, logger=None):
         commands_run.append(cmd)
-        # First call is _find_existing_pr (gh pr view)
-        if "view" in cmd:
+        # First call is _find_existing_pr (gh pr list)
+        if "list" in cmd:
             return _make_result(stdout=existing_url + "\n")
         # Should never reach gh pr create
         return _make_result(returncode=1, stderr="should not be called")
@@ -112,7 +133,7 @@ def test_create_pr_creates_new_when_none_exists(monkeypatch):
     new_url = "https://github.com/owner/repo/pull/30"
 
     def fake_run_command(cmd, *, cwd=None, check=False, shell=None, logger=None):
-        if "view" in cmd:
+        if "list" in cmd:
             return _make_result(returncode=1, stderr="no pull requests found")
         if "create" in cmd:
             return _make_result(stdout=new_url + "\n")
@@ -251,6 +272,44 @@ def test_create_pr_retries_transient_failure(monkeypatch):
     assert len(calls) == 2
 
 
+def test_create_pr_reuses_existing_after_duplicate_error(monkeypatch):
+    """GitHub duplicate-PR errors should resolve to the existing branch PR."""
+    existing_url = "https://github.com/owner/repo/pull/25"
+    create_calls = []
+    find_calls = []
+
+    def fake_find_existing_pr(repo, branch, repo_root):
+        find_calls.append((repo, branch, repo_root))
+        if len(find_calls) == 1:
+            return None
+        return existing_url
+
+    def fake_run_command_or_fail(cmd, *, error_msg, cwd=None, shell=None, logger=None):
+        create_calls.append(cmd)
+        raise pub_mod.CommandError(
+            "PR creation failed: duplicate",
+            subprocess.CompletedProcess(
+                cmd,
+                1,
+                stdout="",
+                stderr=(
+                    'a pull request for branch "claude/24" into branch "main" '
+                    "already exists:\nhttps://github.com/owner/repo/pull/25"
+                ),
+            ),
+        )
+
+    monkeypatch.setattr(pub_mod, "_build_pr_body", lambda issue, repo_root, repo: "short body")
+    monkeypatch.setattr(pub_mod, "_find_existing_pr", fake_find_existing_pr)
+    monkeypatch.setattr(pub_mod, "run_command_or_fail", fake_run_command_or_fail)
+
+    result = _create_pr(REPO, BRANCH, ISSUE, REPO_ROOT)
+
+    assert result == existing_url
+    assert len(create_calls) == 1
+    assert len(find_calls) == 2
+
+
 def test_create_pr_does_not_retry_body_too_long(monkeypatch):
     """Deterministic content failures should fail immediately."""
     calls = []
@@ -349,7 +408,7 @@ def test_publish_without_pr_url_detects_existing(monkeypatch):
             return _make_result(stdout="abc123 some commit\n")
         if "push" in cmd:
             return _make_result()
-        if "view" in cmd:
+        if "list" in cmd:
             return _make_result(stdout=existing_url + "\n")
         return _make_result()
 


### PR DESCRIPTION
## Summary
- Reuse existing open PRs by looking them up with `gh pr list --head` before creating a new PR.
- Treat duplicate PR creation errors as idempotent by resolving the existing branch PR.
- Run one final remote check after the last remediation is published before marking an issue failed.

## Test plan
- `.venv/bin/python -m pytest tests/test_publish.py tests/test_pipeline.py -k 'publish or final_check_after_last_remediation or review_fix_ci_failure_fails_issue or review_fix_triggers_ci_recheck'`


Made with [Cursor](https://cursor.com)