### PR TITLE
Add effort/reasoning_effort flag pass-through for Claude Code and Codex

### DIFF
--- a/aiorchestra/ai/_claude_code.py
+++ b/aiorchestra/ai/_claude_code.py
@@ -52,4 +52,8 @@ class ClaudeCodeProvider(CLIProvider):
         if model:
             cmd.extend(["--model", model])
 
+        effort = self._config.get("effort")
+        if effort:
+            cmd.extend(["--effort", effort])
+
         return cmd

--- a/aiorchestra/ai/_codex.py
+++ b/aiorchestra/ai/_codex.py
@@ -36,5 +36,9 @@ class CodexProvider(CLIProvider):
         if model:
             cmd.extend(["--model", model])
 
+        effort = self._config.get("effort")
+        if effort:
+            cmd.extend(["-c", f"model_reasoning_effort={effort}"])
+
         cmd.append(prompt)
         return cmd

--- a/tests/test_claude_code.py
+++ b/tests/test_claude_code.py
@@ -1,0 +1,74 @@
+"""Tests for the Claude Code CLI provider."""
+
+import subprocess
+
+from aiorchestra.ai import ClaudeCodeProvider, create_provider
+
+
+def _make_provider(**overrides):
+    config = {"provider": "claude-code", **overrides}
+    return ClaudeCodeProvider(config)
+
+
+def _fake_run_capture(captured):
+    def fake_run(cmd, *, capture_output=False, text=False, cwd=None, input=None):
+        captured["cmd"] = cmd
+        captured["cwd"] = cwd
+        captured["input"] = input
+        return subprocess.CompletedProcess(cmd, 0, stdout="ok", stderr="")
+
+    return fake_run
+
+
+def test_claude_basic_invocation(monkeypatch):
+    """Claude is invoked via ``--print`` with stdin-fed prompt."""
+    captured = {}
+    monkeypatch.setattr("aiorchestra.ai._cli.subprocess.run", _fake_run_capture(captured))
+
+    provider = _make_provider()
+    result = provider.run("fix the bug", cwd="/tmp/repo")
+
+    assert result.success
+    assert captured["cmd"][:2] == ["claude", "--print"]
+    assert "--dangerously-skip-permissions" in captured["cmd"]
+    assert captured["input"] == "fix the bug"
+    assert captured["cwd"] == "/tmp/repo"
+
+
+def test_claude_effort_flag(monkeypatch):
+    """``effort`` config maps to ``--effort <level>``."""
+    captured = {}
+    monkeypatch.setattr("aiorchestra.ai._cli.subprocess.run", _fake_run_capture(captured))
+
+    _make_provider(effort="high").run("hello")
+
+    assert "--effort" in captured["cmd"]
+    idx = captured["cmd"].index("--effort")
+    assert captured["cmd"][idx + 1] == "high"
+
+
+def test_claude_no_effort_flag_when_unset(monkeypatch):
+    """Without ``effort`` configured the flag is omitted."""
+    captured = {}
+    monkeypatch.setattr("aiorchestra.ai._cli.subprocess.run", _fake_run_capture(captured))
+
+    _make_provider().run("hello")
+
+    assert "--effort" not in captured["cmd"]
+
+
+def test_claude_custom_model(monkeypatch):
+    """Model flag is forwarded when configured."""
+    captured = {}
+    monkeypatch.setattr("aiorchestra.ai._cli.subprocess.run", _fake_run_capture(captured))
+
+    _make_provider(model="claude-opus-4-7").run("hello")
+
+    idx = captured["cmd"].index("--model")
+    assert captured["cmd"][idx + 1] == "claude-opus-4-7"
+
+
+def test_create_provider_claude_code():
+    """Factory creates ClaudeCodeProvider for provider='claude-code'."""
+    provider = create_provider({"provider": "claude-code"})
+    assert isinstance(provider, ClaudeCodeProvider)

--- a/tests/test_codex.py
+++ b/tests/test_codex.py
@@ -85,6 +85,38 @@ def test_codex_unknown_approval_mode(monkeypatch):
     assert "--sandbox" not in captured["cmd"]
 
 
+def test_codex_effort_flag(monkeypatch):
+    """``effort`` config maps to ``-c model_reasoning_effort=<level>``."""
+    captured = {}
+
+    def fake_run(cmd, **kwargs):
+        captured["cmd"] = cmd
+        return subprocess.CompletedProcess(cmd, 0, stdout="ok", stderr="")
+
+    monkeypatch.setattr("aiorchestra.ai._cli.subprocess.run", fake_run)
+
+    _make_provider(effort="high").run("hello")
+
+    assert "-c" in captured["cmd"]
+    idx = captured["cmd"].index("-c")
+    assert captured["cmd"][idx + 1] == "model_reasoning_effort=high"
+
+
+def test_codex_no_effort_flag_when_unset(monkeypatch):
+    """Without ``effort`` configured the override is omitted."""
+    captured = {}
+
+    def fake_run(cmd, **kwargs):
+        captured["cmd"] = cmd
+        return subprocess.CompletedProcess(cmd, 0, stdout="ok", stderr="")
+
+    monkeypatch.setattr("aiorchestra.ai._cli.subprocess.run", fake_run)
+
+    _make_provider().run("hello")
+
+    assert not any(arg.startswith("model_reasoning_effort=") for arg in captured["cmd"])
+
+
 def test_codex_failure(monkeypatch):
     """Non-zero exit code results in failure."""
 


### PR DESCRIPTION
Both CLIs now expose a reasoning-effort knob (Anthropic's adaptive
thinking replaced the deprecated budget_tokens; OpenAI's reasoning
effort has been around since GPT-5). When `ai.effort` is set in config,
forward it as `--effort <level>` to claude and `-c
model_reasoning_effort=<level>` to codex. Other providers ignore it.