### PR TITLE
docs: add CLI coding agents inventory to think_tank

### DIFF
--- a/aiorchestra/ai/__init__.py
+++ b/aiorchestra/ai/__init__.py
@@ -14,6 +14,7 @@ from aiorchestra.ai._agents import (
     provider_for_agent,
     resolve_agent,
 )
+from aiorchestra.ai._aider import AiderProvider
 from aiorchestra.ai._antigravity import AntigravityProvider
 from aiorchestra.ai._base import AIProvider, InvokeResult, _parse_clarification
 from aiorchestra.ai._claude_code import ClaudeCodeProvider
@@ -28,6 +29,7 @@ from aiorchestra.ai._registry import create_provider
 
 __all__ = [
     "AIProvider",
+    "AiderProvider",
     "AntigravityProvider",
     "CLIProvider",
     "ClaudeCodeProvider",

--- a/aiorchestra/ai/__init__.py
+++ b/aiorchestra/ai/__init__.py
@@ -22,6 +22,7 @@ from aiorchestra.ai._cli import CLIProvider
 from aiorchestra.ai._codex import CodexProvider
 from aiorchestra.ai._cursor import CursorProvider
 from aiorchestra.ai._gemini import GeminiProvider
+from aiorchestra.ai._goose import GooseProvider
 from aiorchestra.ai._jules import JulesProvider
 from aiorchestra.ai._ollama import OllamaProvider
 from aiorchestra.ai._opencode import OpenCodeProvider
@@ -37,6 +38,7 @@ __all__ = [
     "CursorProvider",
     "DEFAULT_AGENT_FAMILY",
     "GeminiProvider",
+    "GooseProvider",
     "InvokeResult",
     "JulesProvider",
     "KNOWN_AGENTS",

--- a/aiorchestra/ai/__init__.py
+++ b/aiorchestra/ai/__init__.py
@@ -14,10 +14,12 @@ from aiorchestra.ai._agents import (
     provider_for_agent,
     resolve_agent,
 )
+from aiorchestra.ai._antigravity import AntigravityProvider
 from aiorchestra.ai._base import AIProvider, InvokeResult, _parse_clarification
 from aiorchestra.ai._claude_code import ClaudeCodeProvider
 from aiorchestra.ai._cli import CLIProvider
 from aiorchestra.ai._codex import CodexProvider
+from aiorchestra.ai._cursor import CursorProvider
 from aiorchestra.ai._gemini import GeminiProvider
 from aiorchestra.ai._jules import JulesProvider
 from aiorchestra.ai._ollama import OllamaProvider
@@ -26,9 +28,11 @@ from aiorchestra.ai._registry import create_provider
 
 __all__ = [
     "AIProvider",
+    "AntigravityProvider",
     "CLIProvider",
     "ClaudeCodeProvider",
     "CodexProvider",
+    "CursorProvider",
     "DEFAULT_AGENT_FAMILY",
     "GeminiProvider",
     "InvokeResult",

--- a/aiorchestra/ai/_agents.py
+++ b/aiorchestra/ai/_agents.py
@@ -4,13 +4,23 @@ from collections.abc import Mapping, Sequence
 from typing import Any
 
 DEFAULT_AGENT_FAMILY = "claude"
-KNOWN_AGENTS: tuple[str, ...] = ("claude", "codex", "gemini", "jules", "opencode")
+KNOWN_AGENTS: tuple[str, ...] = (
+    "claude",
+    "codex",
+    "cursor",
+    "gemini",
+    "antigravity",
+    "jules",
+    "opencode",
+)
 
 # Maps agent family names to the provider id used by the registry.
 _FAMILY_TO_PROVIDER: dict[str, str] = {
     "claude": "claude-code",
     "codex": "codex",
+    "cursor": "cursor",
     "gemini": "gemini",
+    "antigravity": "antigravity",
     "jules": "jules",
     "opencode": "opencode",
 }

--- a/aiorchestra/ai/_agents.py
+++ b/aiorchestra/ai/_agents.py
@@ -5,6 +5,7 @@ from typing import Any
 
 DEFAULT_AGENT_FAMILY = "claude"
 KNOWN_AGENTS: tuple[str, ...] = (
+    "aider",
     "claude",
     "codex",
     "cursor",
@@ -16,6 +17,7 @@ KNOWN_AGENTS: tuple[str, ...] = (
 
 # Maps agent family names to the provider id used by the registry.
 _FAMILY_TO_PROVIDER: dict[str, str] = {
+    "aider": "aider",
     "claude": "claude-code",
     "codex": "codex",
     "cursor": "cursor",

--- a/aiorchestra/ai/_agents.py
+++ b/aiorchestra/ai/_agents.py
@@ -11,6 +11,7 @@ KNOWN_AGENTS: tuple[str, ...] = (
     "cursor",
     "gemini",
     "antigravity",
+    "goose",
     "jules",
     "opencode",
 )
@@ -23,6 +24,7 @@ _FAMILY_TO_PROVIDER: dict[str, str] = {
     "cursor": "cursor",
     "gemini": "gemini",
     "antigravity": "antigravity",
+    "goose": "goose",
     "jules": "jules",
     "opencode": "opencode",
 }

--- a/aiorchestra/ai/_aider.py
+++ b/aiorchestra/ai/_aider.py
@@ -1,0 +1,40 @@
+"""Aider CLI provider."""
+
+from __future__ import annotations
+
+from aiorchestra.ai._cli import CLIProvider
+
+
+class AiderProvider(CLIProvider):
+    """Invokes the ``aider`` CLI in scripting mode (``--message``).
+
+    Aider differs from the other CLI agents in one important way: by default it
+    *commits its own changes to git*.  AIOrchestra's pipeline owns committing
+    (the ``publish`` stage stages and commits publishable changes, and enforces
+    a "commits ahead of base" invariant), so we disable Aider's auto-commit by
+    default and let it only edit the working tree — matching the contract of
+    every other provider.  Set ``auto_commits: true`` to opt back into Aider's
+    native git behaviour.
+
+    ``--message`` sends a single prompt and exits (no interactive chat).
+    ``--no-pretty``/``--no-stream`` give clean, parseable stdout, and
+    ``--yes-always`` auto-confirms file additions and prompts.
+    """
+
+    _cli_name = "aider"
+
+    def _build_command(self, prompt: str) -> list[str]:
+        cmd: list[str] = ["aider", "--no-pretty", "--no-stream"]
+
+        if self._config.get("yes", True):
+            cmd.append("--yes-always")
+
+        if not self._config.get("auto_commits", False):
+            cmd.extend(["--no-auto-commits", "--no-dirty-commits"])
+
+        model = self._config.get("model")
+        if model:
+            cmd.extend(["--model", model])
+
+        cmd.extend(["--message", prompt])
+        return cmd

--- a/aiorchestra/ai/_antigravity.py
+++ b/aiorchestra/ai/_antigravity.py
@@ -1,0 +1,32 @@
+"""Google Antigravity CLI provider."""
+
+from __future__ import annotations
+
+from aiorchestra.ai._cli import CLIProvider
+
+
+class AntigravityProvider(CLIProvider):
+    """Invokes the ``agy`` (Antigravity) CLI in headless (``-p``) mode.
+
+    Antigravity CLI is Google's successor to Gemini CLI.  The ``-p`` flag runs
+    a single prompt non-interactively, emitting the response to stdout.
+    ``--dangerously-skip-permissions`` auto-approves tool use (the analogue of
+    Gemini CLI's ``--yolo``).  Authentication is via ``GEMINI_API_KEY`` /
+    ``ANTIGRAVITY_API_KEY`` or stored OAuth credentials — same as the binary's
+    own expectations, so no extra handling is needed here.
+    """
+
+    _cli_name = "agy"
+
+    def _build_command(self, prompt: str) -> list[str]:
+        cmd: list[str] = ["agy", "-p"]
+
+        if self._config.get("skip_permissions", True):
+            cmd.append("--dangerously-skip-permissions")
+
+        model = self._config.get("model")
+        if model:
+            cmd.extend(["-m", model])
+
+        cmd.append(prompt)
+        return cmd

--- a/aiorchestra/ai/_cursor.py
+++ b/aiorchestra/ai/_cursor.py
@@ -1,0 +1,31 @@
+"""Cursor CLI provider."""
+
+from __future__ import annotations
+
+from aiorchestra.ai._cli import CLIProvider
+
+
+class CursorProvider(CLIProvider):
+    """Invokes the ``cursor-agent`` CLI in print (``-p``) mode.
+
+    Cursor CLI is Anysphere's terminal coding agent.  The ``-p`` flag runs a
+    single prompt non-interactively, writing the result to stdout.  In print
+    mode file edits are only *proposed* unless ``--force`` is passed, so
+    ``force`` defaults to True here to mirror the auto-approve behaviour of the
+    other CLI providers.
+    """
+
+    _cli_name = "cursor-agent"
+
+    def _build_command(self, prompt: str) -> list[str]:
+        cmd: list[str] = ["cursor-agent", "-p"]
+
+        if self._config.get("force", True):
+            cmd.append("--force")
+
+        model = self._config.get("model")
+        if model:
+            cmd.extend(["--model", model])
+
+        cmd.append(prompt)
+        return cmd

--- a/aiorchestra/ai/_goose.py
+++ b/aiorchestra/ai/_goose.py
@@ -1,0 +1,41 @@
+"""Goose CLI provider."""
+
+from __future__ import annotations
+
+from aiorchestra.ai._cli import CLIProvider
+
+
+class GooseProvider(CLIProvider):
+    """Invokes Block's ``goose`` CLI in headless ``goose run`` mode.
+
+    ``goose run -t "<prompt>"`` executes a single instruction and exits.
+    ``--no-session`` is passed by default so Goose doesn't persist session
+    files into the workspace (which would otherwise show up as artifacts);
+    set ``session: true`` to keep them.
+
+    Goose has its own ``--provider`` flag selecting the LLM backend (openai,
+    anthropic, ...), which collides with AIOrchestra's top-level ``provider``
+    key used to pick *this* provider.  It is therefore configured via the
+    distinct ``llm_provider`` key.  ``--model`` works as usual.  Both default
+    to Goose's own configuration (``goose configure`` / ``GOOSE_*`` env vars)
+    when unset.
+    """
+
+    _cli_name = "goose"
+
+    def _build_command(self, prompt: str) -> list[str]:
+        cmd: list[str] = ["goose", "run"]
+
+        if not self._config.get("session", False):
+            cmd.append("--no-session")
+
+        llm_provider = self._config.get("llm_provider")
+        if llm_provider:
+            cmd.extend(["--provider", llm_provider])
+
+        model = self._config.get("model")
+        if model:
+            cmd.extend(["--model", model])
+
+        cmd.extend(["-t", prompt])
+        return cmd

--- a/aiorchestra/ai/_registry.py
+++ b/aiorchestra/ai/_registry.py
@@ -2,17 +2,21 @@
 
 from __future__ import annotations
 
+from aiorchestra.ai._antigravity import AntigravityProvider
 from aiorchestra.ai._base import AIProvider
 from aiorchestra.ai._claude_code import ClaudeCodeProvider
 from aiorchestra.ai._codex import CodexProvider
+from aiorchestra.ai._cursor import CursorProvider
 from aiorchestra.ai._gemini import GeminiProvider
 from aiorchestra.ai._jules import JulesProvider
 from aiorchestra.ai._ollama import OllamaProvider
 from aiorchestra.ai._opencode import OpenCodeProvider
 
 _PROVIDERS: dict[str, type[AIProvider]] = {
+    "antigravity": AntigravityProvider,
     "claude-code": ClaudeCodeProvider,
     "codex": CodexProvider,
+    "cursor": CursorProvider,
     "gemini": GeminiProvider,
     "jules": JulesProvider,
     "ollama": OllamaProvider,

--- a/aiorchestra/ai/_registry.py
+++ b/aiorchestra/ai/_registry.py
@@ -9,6 +9,7 @@ from aiorchestra.ai._claude_code import ClaudeCodeProvider
 from aiorchestra.ai._codex import CodexProvider
 from aiorchestra.ai._cursor import CursorProvider
 from aiorchestra.ai._gemini import GeminiProvider
+from aiorchestra.ai._goose import GooseProvider
 from aiorchestra.ai._jules import JulesProvider
 from aiorchestra.ai._ollama import OllamaProvider
 from aiorchestra.ai._opencode import OpenCodeProvider
@@ -20,6 +21,7 @@ _PROVIDERS: dict[str, type[AIProvider]] = {
     "codex": CodexProvider,
     "cursor": CursorProvider,
     "gemini": GeminiProvider,
+    "goose": GooseProvider,
     "jules": JulesProvider,
     "ollama": OllamaProvider,
     "opencode": OpenCodeProvider,

--- a/aiorchestra/ai/_registry.py
+++ b/aiorchestra/ai/_registry.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+from aiorchestra.ai._aider import AiderProvider
 from aiorchestra.ai._antigravity import AntigravityProvider
 from aiorchestra.ai._base import AIProvider
 from aiorchestra.ai._claude_code import ClaudeCodeProvider
@@ -13,6 +14,7 @@ from aiorchestra.ai._ollama import OllamaProvider
 from aiorchestra.ai._opencode import OpenCodeProvider
 
 _PROVIDERS: dict[str, type[AIProvider]] = {
+    "aider": AiderProvider,
     "antigravity": AntigravityProvider,
     "claude-code": ClaudeCodeProvider,
     "codex": CodexProvider,

--- a/tests/test_aider.py
+++ b/tests/test_aider.py
@@ -1,0 +1,121 @@
+"""Tests for the Aider CLI provider."""
+
+import subprocess
+
+from aiorchestra.ai import AiderProvider, create_provider
+
+
+def _make_provider(**overrides):
+    config = {"provider": "aider", **overrides}
+    return AiderProvider(config)
+
+
+def test_aider_basic_invocation(monkeypatch):
+    """Aider runs with --message, scripting flags, and commits disabled."""
+    captured = {}
+
+    def fake_run(cmd, *, capture_output=False, text=False, cwd=None):
+        captured["cmd"] = cmd
+        captured["cwd"] = cwd
+        return subprocess.CompletedProcess(cmd, 0, stdout="done\n", stderr="")
+
+    monkeypatch.setattr("aiorchestra.ai._cli.subprocess.run", fake_run)
+
+    provider = _make_provider()
+    result = provider.run("fix the bug", cwd="/tmp/repo")
+
+    assert result.success
+    assert result.output == "done\n"
+    cmd = captured["cmd"]
+    assert cmd[0] == "aider"
+    assert "--no-pretty" in cmd
+    assert "--no-stream" in cmd
+    assert "--yes-always" in cmd
+    # The prompt is passed via --message.
+    assert "--message" in cmd
+    idx = cmd.index("--message")
+    assert cmd[idx + 1] == "fix the bug"
+    assert captured["cwd"] == "/tmp/repo"
+
+
+def test_aider_disables_commits_by_default(monkeypatch):
+    """Auto-commit is off by default so the pipeline owns committing."""
+    captured = {}
+
+    def fake_run(cmd, **kwargs):
+        captured["cmd"] = cmd
+        return subprocess.CompletedProcess(cmd, 0, stdout="ok", stderr="")
+
+    monkeypatch.setattr("aiorchestra.ai._cli.subprocess.run", fake_run)
+
+    _make_provider().run("hello")
+
+    assert "--no-auto-commits" in captured["cmd"]
+    assert "--no-dirty-commits" in captured["cmd"]
+
+
+def test_aider_auto_commits_opt_in(monkeypatch):
+    """auto_commits=True restores Aider's native git behaviour."""
+    captured = {}
+
+    def fake_run(cmd, **kwargs):
+        captured["cmd"] = cmd
+        return subprocess.CompletedProcess(cmd, 0, stdout="ok", stderr="")
+
+    monkeypatch.setattr("aiorchestra.ai._cli.subprocess.run", fake_run)
+
+    _make_provider(auto_commits=True).run("hello")
+
+    assert "--no-auto-commits" not in captured["cmd"]
+    assert "--no-dirty-commits" not in captured["cmd"]
+
+
+def test_aider_yes_disabled(monkeypatch):
+    """yes=False omits --yes-always."""
+    captured = {}
+
+    def fake_run(cmd, **kwargs):
+        captured["cmd"] = cmd
+        return subprocess.CompletedProcess(cmd, 0, stdout="ok", stderr="")
+
+    monkeypatch.setattr("aiorchestra.ai._cli.subprocess.run", fake_run)
+
+    _make_provider(yes=False).run("hello")
+
+    assert "--yes-always" not in captured["cmd"]
+
+
+def test_aider_custom_model(monkeypatch):
+    """Model flag is forwarded when configured."""
+    captured = {}
+
+    def fake_run(cmd, **kwargs):
+        captured["cmd"] = cmd
+        return subprocess.CompletedProcess(cmd, 0, stdout="ok", stderr="")
+
+    monkeypatch.setattr("aiorchestra.ai._cli.subprocess.run", fake_run)
+
+    _make_provider(model="sonnet").run("hello")
+
+    assert "--model" in captured["cmd"]
+    idx = captured["cmd"].index("--model")
+    assert captured["cmd"][idx + 1] == "sonnet"
+
+
+def test_aider_failure(monkeypatch):
+    """Non-zero exit code results in failure."""
+
+    def fake_run(cmd, **kwargs):
+        return subprocess.CompletedProcess(cmd, 1, stdout="", stderr="aider error")
+
+    monkeypatch.setattr("aiorchestra.ai._cli.subprocess.run", fake_run)
+
+    result = _make_provider().run("hello")
+
+    assert not result.success
+
+
+def test_aider_via_registry():
+    """The registry resolves the aider provider id."""
+    provider = create_provider({"provider": "aider"})
+    assert isinstance(provider, AiderProvider)

--- a/tests/test_antigravity.py
+++ b/tests/test_antigravity.py
@@ -1,0 +1,86 @@
+"""Tests for the Antigravity CLI provider."""
+
+import subprocess
+
+from aiorchestra.ai import AntigravityProvider, create_provider
+
+
+def _make_provider(**overrides):
+    config = {"provider": "antigravity", **overrides}
+    return AntigravityProvider(config)
+
+
+def test_antigravity_basic_invocation(monkeypatch):
+    """Antigravity is invoked with -p and skips permissions by default."""
+    captured = {}
+
+    def fake_run(cmd, *, capture_output=False, text=False, cwd=None):
+        captured["cmd"] = cmd
+        captured["cwd"] = cwd
+        return subprocess.CompletedProcess(cmd, 0, stdout="done\n", stderr="")
+
+    monkeypatch.setattr("aiorchestra.ai._cli.subprocess.run", fake_run)
+
+    provider = _make_provider()
+    result = provider.run("fix the bug", cwd="/tmp/repo")
+
+    assert result.success
+    assert result.output == "done\n"
+    assert captured["cmd"][:2] == ["agy", "-p"]
+    assert "--dangerously-skip-permissions" in captured["cmd"]
+    assert "fix the bug" in captured["cmd"]
+    assert captured["cwd"] == "/tmp/repo"
+
+
+def test_antigravity_skip_permissions_disabled(monkeypatch):
+    """skip_permissions=False omits the --dangerously-skip-permissions flag."""
+    captured = {}
+
+    def fake_run(cmd, **kwargs):
+        captured["cmd"] = cmd
+        return subprocess.CompletedProcess(cmd, 0, stdout="ok", stderr="")
+
+    monkeypatch.setattr("aiorchestra.ai._cli.subprocess.run", fake_run)
+
+    provider = _make_provider(skip_permissions=False)
+    provider.run("hello")
+
+    assert "--dangerously-skip-permissions" not in captured["cmd"]
+
+
+def test_antigravity_custom_model(monkeypatch):
+    """Model flag is forwarded via -m when configured."""
+    captured = {}
+
+    def fake_run(cmd, **kwargs):
+        captured["cmd"] = cmd
+        return subprocess.CompletedProcess(cmd, 0, stdout="ok", stderr="")
+
+    monkeypatch.setattr("aiorchestra.ai._cli.subprocess.run", fake_run)
+
+    provider = _make_provider(model="gemini-3-pro")
+    provider.run("hello")
+
+    assert "-m" in captured["cmd"]
+    idx = captured["cmd"].index("-m")
+    assert captured["cmd"][idx + 1] == "gemini-3-pro"
+
+
+def test_antigravity_failure(monkeypatch):
+    """Non-zero exit code results in failure."""
+
+    def fake_run(cmd, **kwargs):
+        return subprocess.CompletedProcess(cmd, 1, stdout="", stderr="agy error")
+
+    monkeypatch.setattr("aiorchestra.ai._cli.subprocess.run", fake_run)
+
+    provider = _make_provider()
+    result = provider.run("hello")
+
+    assert not result.success
+
+
+def test_antigravity_via_registry():
+    """The registry resolves the antigravity provider id."""
+    provider = create_provider({"provider": "antigravity"})
+    assert isinstance(provider, AntigravityProvider)

--- a/tests/test_cursor.py
+++ b/tests/test_cursor.py
@@ -1,0 +1,86 @@
+"""Tests for the Cursor CLI provider."""
+
+import subprocess
+
+from aiorchestra.ai import CursorProvider, create_provider
+
+
+def _make_provider(**overrides):
+    config = {"provider": "cursor", **overrides}
+    return CursorProvider(config)
+
+
+def test_cursor_basic_invocation(monkeypatch):
+    """Cursor is invoked with -p and --force by default."""
+    captured = {}
+
+    def fake_run(cmd, *, capture_output=False, text=False, cwd=None):
+        captured["cmd"] = cmd
+        captured["cwd"] = cwd
+        return subprocess.CompletedProcess(cmd, 0, stdout="done\n", stderr="")
+
+    monkeypatch.setattr("aiorchestra.ai._cli.subprocess.run", fake_run)
+
+    provider = _make_provider()
+    result = provider.run("fix the bug", cwd="/tmp/repo")
+
+    assert result.success
+    assert result.output == "done\n"
+    assert captured["cmd"][:2] == ["cursor-agent", "-p"]
+    assert "--force" in captured["cmd"]
+    assert "fix the bug" in captured["cmd"]
+    assert captured["cwd"] == "/tmp/repo"
+
+
+def test_cursor_force_disabled(monkeypatch):
+    """force=False omits the --force flag."""
+    captured = {}
+
+    def fake_run(cmd, **kwargs):
+        captured["cmd"] = cmd
+        return subprocess.CompletedProcess(cmd, 0, stdout="ok", stderr="")
+
+    monkeypatch.setattr("aiorchestra.ai._cli.subprocess.run", fake_run)
+
+    provider = _make_provider(force=False)
+    provider.run("hello")
+
+    assert "--force" not in captured["cmd"]
+
+
+def test_cursor_custom_model(monkeypatch):
+    """Model flag is forwarded when configured."""
+    captured = {}
+
+    def fake_run(cmd, **kwargs):
+        captured["cmd"] = cmd
+        return subprocess.CompletedProcess(cmd, 0, stdout="ok", stderr="")
+
+    monkeypatch.setattr("aiorchestra.ai._cli.subprocess.run", fake_run)
+
+    provider = _make_provider(model="claude-4-sonnet")
+    provider.run("hello")
+
+    assert "--model" in captured["cmd"]
+    idx = captured["cmd"].index("--model")
+    assert captured["cmd"][idx + 1] == "claude-4-sonnet"
+
+
+def test_cursor_failure(monkeypatch):
+    """Non-zero exit code results in failure."""
+
+    def fake_run(cmd, **kwargs):
+        return subprocess.CompletedProcess(cmd, 1, stdout="", stderr="cursor error")
+
+    monkeypatch.setattr("aiorchestra.ai._cli.subprocess.run", fake_run)
+
+    provider = _make_provider()
+    result = provider.run("hello")
+
+    assert not result.success
+
+
+def test_cursor_via_registry():
+    """The registry resolves the cursor provider id."""
+    provider = create_provider({"provider": "cursor"})
+    assert isinstance(provider, CursorProvider)

--- a/tests/test_goose.py
+++ b/tests/test_goose.py
@@ -1,0 +1,105 @@
+"""Tests for the Goose CLI provider."""
+
+import subprocess
+
+from aiorchestra.ai import GooseProvider, create_provider
+
+
+def _make_provider(**overrides):
+    config = {"provider": "goose", **overrides}
+    return GooseProvider(config)
+
+
+def test_goose_basic_invocation(monkeypatch):
+    """Goose runs `goose run --no-session -t <prompt>`."""
+    captured = {}
+
+    def fake_run(cmd, *, capture_output=False, text=False, cwd=None):
+        captured["cmd"] = cmd
+        captured["cwd"] = cwd
+        return subprocess.CompletedProcess(cmd, 0, stdout="done\n", stderr="")
+
+    monkeypatch.setattr("aiorchestra.ai._cli.subprocess.run", fake_run)
+
+    provider = _make_provider()
+    result = provider.run("fix the bug", cwd="/tmp/repo")
+
+    assert result.success
+    assert result.output == "done\n"
+    cmd = captured["cmd"]
+    assert cmd[:2] == ["goose", "run"]
+    assert "--no-session" in cmd
+    # Prompt is passed via -t.
+    assert "-t" in cmd
+    idx = cmd.index("-t")
+    assert cmd[idx + 1] == "fix the bug"
+    assert captured["cwd"] == "/tmp/repo"
+
+
+def test_goose_session_opt_in(monkeypatch):
+    """session=True keeps Goose's session file (omits --no-session)."""
+    captured = {}
+
+    def fake_run(cmd, **kwargs):
+        captured["cmd"] = cmd
+        return subprocess.CompletedProcess(cmd, 0, stdout="ok", stderr="")
+
+    monkeypatch.setattr("aiorchestra.ai._cli.subprocess.run", fake_run)
+
+    _make_provider(session=True).run("hello")
+
+    assert "--no-session" not in captured["cmd"]
+
+
+def test_goose_llm_provider_and_model(monkeypatch):
+    """llm_provider maps to --provider and model maps to --model."""
+    captured = {}
+
+    def fake_run(cmd, **kwargs):
+        captured["cmd"] = cmd
+        return subprocess.CompletedProcess(cmd, 0, stdout="ok", stderr="")
+
+    monkeypatch.setattr("aiorchestra.ai._cli.subprocess.run", fake_run)
+
+    _make_provider(llm_provider="anthropic", model="claude-sonnet-4-6").run("hello")
+
+    cmd = captured["cmd"]
+    assert "--provider" in cmd
+    assert cmd[cmd.index("--provider") + 1] == "anthropic"
+    assert "--model" in cmd
+    assert cmd[cmd.index("--model") + 1] == "claude-sonnet-4-6"
+
+
+def test_goose_no_model_flags_by_default(monkeypatch):
+    """Without config, no --provider/--model flags are added."""
+    captured = {}
+
+    def fake_run(cmd, **kwargs):
+        captured["cmd"] = cmd
+        return subprocess.CompletedProcess(cmd, 0, stdout="ok", stderr="")
+
+    monkeypatch.setattr("aiorchestra.ai._cli.subprocess.run", fake_run)
+
+    _make_provider().run("hello")
+
+    assert "--provider" not in captured["cmd"]
+    assert "--model" not in captured["cmd"]
+
+
+def test_goose_failure(monkeypatch):
+    """Non-zero exit code results in failure."""
+
+    def fake_run(cmd, **kwargs):
+        return subprocess.CompletedProcess(cmd, 1, stdout="", stderr="goose error")
+
+    monkeypatch.setattr("aiorchestra.ai._cli.subprocess.run", fake_run)
+
+    result = _make_provider().run("hello")
+
+    assert not result.success
+
+
+def test_goose_via_registry():
+    """The registry resolves the goose provider id."""
+    provider = create_provider({"provider": "goose"})
+    assert isinstance(provider, GooseProvider)

--- a/think_tank/cli-agents-inventory.md
+++ b/think_tank/cli-agents-inventory.md
@@ -1,0 +1,110 @@
+# CLI Coding Agents — Inventory & Candidates
+
+**Status:** Survey (no decision)
+**Date:** 2026-05-24
+**Author:** AI evaluation
+
+## Purpose
+
+Track the landscape of terminal/CLI coding agents so we can decide which to
+add as providers. This is an inventory, not an ADR — adding any of these is a
+follow-up decision per agent.
+
+## Currently supported
+
+From `aiorchestra/ai/_registry.py` and `_agents.py`:
+
+| Provider id | Family | Base class | Binary |
+|---|---|---|---|
+| `claude-code` | claude | `CLIProvider` | `claude` |
+| `codex` | codex | `CLIProvider` | `codex` |
+| `gemini` | gemini | `CLIProvider` | `gemini` |
+| `jules` | jules | (Jules) | — |
+| `ollama` | — | (Ollama) | `ollama` |
+| `opencode` | opencode | `CLIProvider` | `opencode` |
+
+## Candidate fit criteria
+
+A CLI agent is a clean fit for the existing `CLIProvider` base
+(`aiorchestra/ai/_cli.py`) when it has:
+
+1. A binary discoverable via `shutil.which()`.
+2. A **non-interactive / print / exec** mode: prompt in → result on stdout,
+   exit code signals success.
+3. A way to auto-approve tool use (no interactive confirmation prompts).
+
+All candidates below shell out to an external CLI, so none add a new Python
+runtime dependency — no ADR required per CLAUDE.md ("No new runtime
+dependencies without an ADR"). Each still needs its own `_<provider>.py`,
+registry + `__init__` wiring, an `available()` check, and tests.
+
+## Tier 1 — explicitly requested
+
+| Tool | Maker | OSS? | Binary | Non-interactive invoke | Notes |
+|---|---|---|---|---|---|
+| **Cursor CLI** | Cursor (Anysphere) | proprietary | `cursor-agent` | `cursor-agent -p "…"` | Clean print mode for CI. Reads `AGENTS.md`/`CLAUDE.md` + `.cursor/rules`, supports MCP. Install: `curl https://cursor.com/install -fsSL \| bash`. Beta. |
+| **Grok Build** (official) | xAI | proprietary | `grok` | plan/exec mode (confirm flag) | **Gated**: SuperGrok Heavy (~$300/mo) at time of writing. Install: `curl -fsSL https://x.ai/cli/install.sh \| bash`. Subagents, Grok 4.3 beta, 2M ctx. |
+| **grok-cli** (community alt) | superagent-ai / vibe-kit | OSS (MIT) | `grok` | `grok --prompt "…"` | Unaffiliated with xAI; thin wrapper over the Grok API. Not gated — easier first integration than official Grok Build. `npm @vibe-kit/grok-cli`. |
+| **Codebuff / Freebuff** | CodebuffAI | OSS | `codebuff` / `freebuff` | print mode + SDK | "freebuff" = free, **ad-supported** edition (text ads printed in CLI). Multi-subagent. Defaults to DeepSeek/Kimi/MiniMax. `npx freebuff`. |
+
+## Tier 2 — high-priority, well-established (non-interactive mode exists)
+
+| Tool | Maker | OSS? | Binary | Non-interactive invoke | Notes |
+|---|---|---|---|---|---|
+| **Aider** | Aider-AI | OSS | `aider` | `aider --message "…" --yes` | The original terminal pair-programmer; best git integration. Model-agnostic. |
+| **Goose** | Block | OSS (Apache-2) | `goose` | `goose run -t "…"` | MCP-native from day one; model-agnostic. |
+| **Crush** | Charmbracelet | OSS (Go) | `crush` | `crush run "…"` | TUI-first, LSP-enhanced, mid-session model switching. |
+| **Amp** | Sourcegraph | proprietary | `amp` | `amp -x "…"` | npm `@sourcegraph/amp`. "Deep mode" extended reasoning. CLI rebuilt 2026. |
+| **Qwen Code** | Alibaba / QwenLM | OSS | `qwen` | `qwen -p "…"` | Gemini-CLI fork tuned for Qwen models; OpenAI/Anthropic/Gemini-compatible APIs. |
+| **Continue CLI** | Continue | OSS | `cn` | `cn -p "…"` | Headless mode; multi-model. |
+| **GitHub Copilot CLI** | GitHub | proprietary | `copilot` | `copilot -p "…"` | PR/issue workflows, headless automation. |
+| **Droid** | Factory | proprietary | `droid` | `droid exec "…"` | Reported #1 on Terminal-Bench; specialized subagents. |
+
+## Tier 3 — secondary / niche (worth tracking)
+
+| Tool | Maker | OSS? | Binary | Notes |
+|---|---|---|---|---|
+| **OpenHands CLI** | All-Hands-AI | OSS | `openhands` | Ex-OpenDevin; agentic dev env, headless mode. |
+| **Plandex** | Plandex | OSS | `plandex` / `pdx` | Plan-first multi-file development. |
+| **Forge (ForgeCode)** | antinomyhq | OSS | `forge` | 300+ models via your own keys. |
+| **SWE-agent** | Princeton | OSS | `sweagent` | Optimized for repo issue resolution (SWE-bench). |
+| **Open Interpreter** | OpenInterpreter | OSS | `interpreter` | General autonomous code/command execution. |
+| **Cline CLI** | Cline | OSS | `cline` | Model-agnostic autonomous planning. |
+| **Roo Code CLI** | Roo | OSS | `roo` | Multi-mode (architect/code/debug/orchestrator). |
+| **Mistral (Vibe) CLI** | Mistral | proprietary | `mistral`/`vibe` | Conversational repo edits. Confirm binary + non-interactive flag. |
+| **Warp** | Warp | proprietary | `warp` | Agent mode inside the Warp terminal; less of a scriptable CLI. |
+
+## ⚠️ Affects an existing provider: Gemini CLI → Antigravity CLI
+
+Multiple sources report Google **retired Gemini CLI at I/O on 2026-05-19** and
+replaced it with **Antigravity CLI** (part of Antigravity 2.0). Gemini CLI
+reportedly **stops serving free/Pro/Ultra accounts on 2026-06-18**.
+
+Action: our existing `gemini` provider (binary `gemini`) likely needs to
+migrate to the `antigravity` binary before that date. Track this **separately**
+from the "add new agents" work — it is maintenance of a shipped provider, not
+a new addition.
+
+## Sourcing caveats
+
+The largest aggregator surveyed (`bradAGI/awesome-cli-coding-agents`) also
+lists an "OpenClaw / Claw Code / ZeroClaw / NullClaw / PicoClaw" cluster with
+very large star counts. These could not be independently verified and may be
+list padding — **confirm independently before treating any as real**. They are
+deliberately excluded from the tiers above.
+
+Tool details (binaries, flags, gating, pricing) change fast in this space;
+re-verify each candidate's non-interactive invocation and auth model at
+implementation time.
+
+## Suggested next steps
+
+1. Pick a first batch to implement. Recommended for breadth + low friction:
+   **Cursor CLI**, **Aider**, **Goose** (all have clean non-interactive modes
+   and broad adoption).
+2. For Grok, start with the community **grok-cli** (not gated) rather than
+   official Grok Build.
+3. Open a separate task for the **Gemini → Antigravity** migration.
+4. For each chosen agent, follow the "Adding new AI providers" checklist in
+   CLAUDE.md (`_<provider>.py` → registry → `__init__` → `available()` →
+   tests).

--- a/think_tank/cli-agents-inventory.md
+++ b/think_tank/cli-agents-inventory.md
@@ -10,6 +10,20 @@ Track the landscape of terminal/CLI coding agents so we can decide which to
 add as providers. This is an inventory, not an ADR — adding any of these is a
 follow-up decision per agent.
 
+## Implementation status (2026-05-24)
+
+Priority set by maintainer: **(1) Antigravity, (2) Cursor, (3) Freebuff**.
+
+| Agent | Provider id | Binary | Status |
+|---|---|---|---|
+| Antigravity CLI | `antigravity` | `agy` | **Added** — `_antigravity.py`, registry, tests |
+| Cursor CLI | `cursor` | `cursor-agent` | **Added** — `_cursor.py`, registry, tests |
+| Freebuff | — | `freebuff` | **Blocked** — no documented non-interactive mode (see below) |
+
+Both new providers extend `CLIProvider` and add no Python runtime deps.
+Note: `antigravity` is added as a **new** provider; the Gemini-CLI retirement
+migration (below) remains a separate open item.
+
 ## Currently supported
 
 From `aiorchestra/ai/_registry.py` and `_agents.py`:
@@ -45,7 +59,7 @@ registry + `__init__` wiring, an `available()` check, and tests.
 | **Cursor CLI** | Cursor (Anysphere) | proprietary | `cursor-agent` | `cursor-agent -p "…"` | Clean print mode for CI. Reads `AGENTS.md`/`CLAUDE.md` + `.cursor/rules`, supports MCP. Install: `curl https://cursor.com/install -fsSL \| bash`. Beta. |
 | **Grok Build** (official) | xAI | proprietary | `grok` | plan/exec mode (confirm flag) | **Gated**: SuperGrok Heavy (~$300/mo) at time of writing. Install: `curl -fsSL https://x.ai/cli/install.sh \| bash`. Subagents, Grok 4.3 beta, 2M ctx. |
 | **grok-cli** (community alt) | superagent-ai / vibe-kit | OSS (MIT) | `grok` | `grok --prompt "…"` | Unaffiliated with xAI; thin wrapper over the Grok API. Not gated — easier first integration than official Grok Build. `npm @vibe-kit/grok-cli`. |
-| **Codebuff / Freebuff** | CodebuffAI | OSS | `codebuff` / `freebuff` | print mode + SDK | "freebuff" = free, **ad-supported** edition (text ads printed in CLI). Multi-subagent. Defaults to DeepSeek/Kimi/MiniMax. `npx freebuff`. |
+| **Codebuff / Freebuff** | CodebuffAI | OSS | `codebuff` / `freebuff` | **none documented** (interactive TUI only) | "freebuff" = free, **ad-supported** edition (text ads printed in CLI). Multi-subagent. Defaults to DeepSeek/Kimi/MiniMax. `npm i -g freebuff`. **Blocker:** both the Freebuff and Codebuff READMEs document only the interactive TUI — no `-p`/`--print`/`run`/`exec` one-shot flag — so it does not fit `CLIProvider`. A programmatic path exists via the `@codebuff/sdk` (TypeScript), which is a different integration shape than shelling out to a binary. |
 
 ## Tier 2 — high-priority, well-established (non-interactive mode exists)
 
@@ -81,9 +95,10 @@ replaced it with **Antigravity CLI** (part of Antigravity 2.0). Gemini CLI
 reportedly **stops serving free/Pro/Ultra accounts on 2026-06-18**.
 
 Action: our existing `gemini` provider (binary `gemini`) likely needs to
-migrate to the `antigravity` binary before that date. Track this **separately**
-from the "add new agents" work — it is maintenance of a shipped provider, not
-a new addition.
+migrate to the `agy` (Antigravity) binary before that date. Track this
+**separately** from the "add new agents" work — it is maintenance of a shipped
+provider, not a new addition. Note the new `antigravity` provider added in this
+branch is a *distinct* entry; it does not retire or replace `gemini`.
 
 ## Sourcing caveats
 

--- a/think_tank/cli-agents-inventory.md
+++ b/think_tank/cli-agents-inventory.md
@@ -13,13 +13,14 @@ follow-up decision per agent.
 ## Implementation status (2026-05-24)
 
 Priority set by maintainer: **(1) Antigravity, (2) Cursor, (3) Freebuff**;
-**Aider** added afterwards.
+**Aider** and **Goose** added afterwards.
 
 | Agent | Provider id | Binary | Status |
 |---|---|---|---|
 | Antigravity CLI | `antigravity` | `agy` | **Added** — `_antigravity.py`, registry, tests |
 | Cursor CLI | `cursor` | `cursor-agent` | **Added** — `_cursor.py`, registry, tests |
 | Aider | `aider` | `aider` | **Added** — `_aider.py`, registry, tests; auto-commit disabled by default (see Tier 2) |
+| Goose | `goose` | `goose` | **Added** — `_goose.py`, registry, tests; `--no-session` by default, LLM backend via `llm_provider` (see Tier 2) |
 | Freebuff | — | `freebuff` | **Skipped** — no documented non-interactive mode + self-downloading npm stub (see below) |
 
 All new providers extend `CLIProvider` and add no Python runtime deps.
@@ -69,7 +70,7 @@ registry + `__init__` wiring, an `available()` check, and tests.
 | Tool | Maker | OSS? | Binary | Non-interactive invoke | Notes |
 |---|---|---|---|---|---|
 | **Aider** | Aider-AI | OSS | `aider` | `aider --message "…" --yes-always` | **Added.** The original terminal pair-programmer. Differs from the others: it auto-commits to git by default. Our provider disables that (`--no-auto-commits --no-dirty-commits`) so the `publish` stage owns committing; set `auto_commits: true` to opt back in. Also uses `--no-pretty --no-stream` for clean stdout. Model-agnostic. |
-| **Goose** | Block | OSS (Apache-2) | `goose` | `goose run -t "…"` | MCP-native from day one; model-agnostic. |
+| **Goose** | Block | OSS (Apache-2) | `goose` | `goose run --no-session -t "…"` | **Added.** MCP-native; model-agnostic. Headless `goose run`; we pass `--no-session` by default so it doesn't drop session files in the workspace (`session: true` to keep). Goose's own `--provider` (LLM backend) is set via the `llm_provider` config key to avoid clashing with AIOrchestra's `provider` selector; `--model` as usual. |
 | **Crush** | Charmbracelet | OSS (Go) | `crush` | `crush run "…"` | TUI-first, LSP-enhanced, mid-session model switching. |
 | **Amp** | Sourcegraph | proprietary | `amp` | `amp -x "…"` | npm `@sourcegraph/amp`. "Deep mode" extended reasoning. CLI rebuilt 2026. |
 | **Qwen Code** | Alibaba / QwenLM | OSS | `qwen` | `qwen -p "…"` | Gemini-CLI fork tuned for Qwen models; OpenAI/Anthropic/Gemini-compatible APIs. |
@@ -117,13 +118,11 @@ implementation time.
 
 ## Suggested next steps
 
-1. **Done:** Antigravity, Cursor, Aider providers added.
-2. Remaining easy win with a clean non-interactive mode: **Goose**
-   (`goose run -t "…"`).
-3. For Grok, start with the community **grok-cli** (not gated) rather than
+1. **Done:** Antigravity, Cursor, Aider, Goose providers added.
+2. For Grok, start with the community **grok-cli** (not gated) rather than
    official Grok Build.
-4. Keep the **Gemini → Antigravity** retirement as a separate future task
+3. Keep the **Gemini → Antigravity** retirement as a separate future task
    (Gemini stays for now).
-5. For each chosen agent, follow the "Adding new AI providers" checklist in
+4. For each chosen agent, follow the "Adding new AI providers" checklist in
    CLAUDE.md (`_<provider>.py` → registry → `__init__` → `available()` →
    tests).

--- a/think_tank/cli-agents-inventory.md
+++ b/think_tank/cli-agents-inventory.md
@@ -12,17 +12,20 @@ follow-up decision per agent.
 
 ## Implementation status (2026-05-24)
 
-Priority set by maintainer: **(1) Antigravity, (2) Cursor, (3) Freebuff**.
+Priority set by maintainer: **(1) Antigravity, (2) Cursor, (3) Freebuff**;
+**Aider** added afterwards.
 
 | Agent | Provider id | Binary | Status |
 |---|---|---|---|
 | Antigravity CLI | `antigravity` | `agy` | **Added** — `_antigravity.py`, registry, tests |
 | Cursor CLI | `cursor` | `cursor-agent` | **Added** — `_cursor.py`, registry, tests |
-| Freebuff | — | `freebuff` | **Blocked** — no documented non-interactive mode (see below) |
+| Aider | `aider` | `aider` | **Added** — `_aider.py`, registry, tests; auto-commit disabled by default (see Tier 2) |
+| Freebuff | — | `freebuff` | **Skipped** — no documented non-interactive mode + self-downloading npm stub (see below) |
 
-Both new providers extend `CLIProvider` and add no Python runtime deps.
+All new providers extend `CLIProvider` and add no Python runtime deps.
 Note: `antigravity` is added as a **new** provider; the Gemini-CLI retirement
-migration (below) remains a separate open item.
+migration (below) remains a separate open item — Gemini stays for now and will
+be removed eventually (maintainer decision, 2026-05-24).
 
 ## Currently supported
 
@@ -65,7 +68,7 @@ registry + `__init__` wiring, an `available()` check, and tests.
 
 | Tool | Maker | OSS? | Binary | Non-interactive invoke | Notes |
 |---|---|---|---|---|---|
-| **Aider** | Aider-AI | OSS | `aider` | `aider --message "…" --yes` | The original terminal pair-programmer; best git integration. Model-agnostic. |
+| **Aider** | Aider-AI | OSS | `aider` | `aider --message "…" --yes-always` | **Added.** The original terminal pair-programmer. Differs from the others: it auto-commits to git by default. Our provider disables that (`--no-auto-commits --no-dirty-commits`) so the `publish` stage owns committing; set `auto_commits: true` to opt back in. Also uses `--no-pretty --no-stream` for clean stdout. Model-agnostic. |
 | **Goose** | Block | OSS (Apache-2) | `goose` | `goose run -t "…"` | MCP-native from day one; model-agnostic. |
 | **Crush** | Charmbracelet | OSS (Go) | `crush` | `crush run "…"` | TUI-first, LSP-enhanced, mid-session model switching. |
 | **Amp** | Sourcegraph | proprietary | `amp` | `amp -x "…"` | npm `@sourcegraph/amp`. "Deep mode" extended reasoning. CLI rebuilt 2026. |
@@ -114,12 +117,13 @@ implementation time.
 
 ## Suggested next steps
 
-1. Pick a first batch to implement. Recommended for breadth + low friction:
-   **Cursor CLI**, **Aider**, **Goose** (all have clean non-interactive modes
-   and broad adoption).
-2. For Grok, start with the community **grok-cli** (not gated) rather than
+1. **Done:** Antigravity, Cursor, Aider providers added.
+2. Remaining easy win with a clean non-interactive mode: **Goose**
+   (`goose run -t "…"`).
+3. For Grok, start with the community **grok-cli** (not gated) rather than
    official Grok Build.
-3. Open a separate task for the **Gemini → Antigravity** migration.
-4. For each chosen agent, follow the "Adding new AI providers" checklist in
+4. Keep the **Gemini → Antigravity** retirement as a separate future task
+   (Gemini stays for now).
+5. For each chosen agent, follow the "Adding new AI providers" checklist in
    CLAUDE.md (`_<provider>.py` → registry → `__init__` → `available()` →
    tests).


### PR DESCRIPTION
Survey of terminal/CLI coding agents to evaluate as new providers,
including Cursor CLI, Grok Build/grok-cli, and Codebuff/Freebuff, plus
a flag that Gemini CLI is being retired in favor of Antigravity CLI.

https://claude.ai/code/session_01LUwbDZbJiyBeW439wweQFC